### PR TITLE
[rocblas] Use enqueue_native_command ext if available

### DIFF
--- a/src/blas/backends/rocblas/rocblas_batch.cpp
+++ b/src/blas/backends/rocblas/rocblas_batch.cpp
@@ -87,7 +87,7 @@ inline void copy_batch(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T,
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, stridex, y_, incy, stridey,
+            rocblas_native_func(func, err, handle, n, x_, incx, stridex, y_, incy, stridey,
                                     batch_size);
         });
     });
@@ -123,7 +123,7 @@ inline void axpy_batch(Func func, sycl::queue &queue, int64_t n, T alpha, sycl::
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, (rocDataType *)&alpha, x_, incx, stridex,
+            rocblas_native_func(func, err, handle, n, (rocDataType *)&alpha, x_, incx, stridex,
                                     y_, incy, stridey, batch_size);
         });
     });
@@ -163,7 +163,7 @@ inline void gemv_batch(Func func, sycl::queue &queue, transpose trans, int64_t m
             auto x_ = sc.get_mem<const rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans), m, n,
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans), m, n,
                                     (rocDataType *)&alpha, a_, lda, stridea, x_, incx, stridex,
                                     (rocDataType *)&beta, y_, incy, stridey, batch_size);
         });
@@ -205,7 +205,7 @@ inline void dgmm_batch(Func func, sycl::queue &queue, side left_right, int64_t m
             auto x_ = sc.get_mem<const rocDataType *>(x_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right), m, n, a_,
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right), m, n, a_,
                                     lda, stridea, x_, incx, stridex, c_, ldc, stridec, batch_size);
         });
     });
@@ -253,7 +253,7 @@ inline void gemm_batch_impl(sycl::queue &queue, transpose transa, transpose tran
             auto c_ = sc.get_mem<rocTypeC *>(c_acc);
 
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(rocblas_gemm_strided_batched_ex, err, handle,
+            rocblas_native_func(rocblas_gemm_strided_batched_ex, err, handle,
                                     get_rocblas_operation(transa), get_rocblas_operation(transb), m,
                                     n, k, &alpha, a_, get_rocblas_datatype<rocTypeA>(), lda,
                                     stridea, b_, get_rocblas_datatype<rocTypeB>(), ldb, strideb,
@@ -320,7 +320,7 @@ inline void trsm_batch(Func func, sycl::queue &queue, side left_right, uplo uppe
             auto a_ = sc.get_mem<const rocDataType *>(a_acc);
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, stridea, b_, ldb, strideb,
@@ -362,7 +362,7 @@ inline void syrk_batch(Func func, sycl::queue &queue, uplo upper_lower, transpos
             auto a_ = sc.get_mem<const rocDataType *>(a_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, stridea, (rocDataType *)&beta, c_, ldc, stridec,
                                     batch_size);
@@ -406,7 +406,7 @@ inline void omatcopy_batch(Func func, sycl::queue &queue, transpose trans, int64
             auto a_ = sc.get_mem<const rocDataType *>(a_acc);
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans),
                                     get_rocblas_operation(trans), new_m, new_n,
                                     (rocDataType *)&alpha, a_, lda, stridea, (rocDataType *)&beta,
                                     nullptr, lda, stridea, b_, ldb, strideb, batch_size);
@@ -474,7 +474,7 @@ inline void omatadd_batch(Func func, sycl::queue &queue, transpose transa, trans
             auto b_ = sc.get_mem<const rocDataType *>(b_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(transa),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(transa),
                                     get_rocblas_operation(transb), m, n, (rocDataType *)&alpha, a_,
                                     lda, stridea, (rocDataType *)&beta, b_, ldb, strideb, c_, ldc,
                                     stridec, batch_size);
@@ -520,7 +520,7 @@ inline sycl::event copy_batch(Func func, sycl::queue &queue, int64_t *n, const T
             for (int64_t i = 0; i < group_count; i++) {
                 auto **x_ = reinterpret_cast<const rocDataType **>(x);
                 auto **y_ = reinterpret_cast<rocDataType **>(y);
-                ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, (int)n[i], x_ + offset, (int)incx[i],
+                rocblas_native_func(func, err, handle, (int)n[i], x_ + offset, (int)incx[i],
                                         y_ + offset, (int)incy[i], (int)group_size[i]);
                 offset += group_size[i];
             }
@@ -560,7 +560,7 @@ inline sycl::event copy_batch(Func func, sycl::queue &queue, int64_t n, const T 
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, stridex, y_, incy, stridey,
+            rocblas_native_func(func, err, handle, n, x_, incx, stridex, y_, incy, stridey,
                                     batch_size);
         });
     });
@@ -602,7 +602,7 @@ inline sycl::event axpy_batch(Func func, sycl::queue &queue, int64_t *n, T *alph
             for (int64_t i = 0; i < group_count; i++) {
                 auto **x_ = reinterpret_cast<const rocDataType **>(x);
                 auto **y_ = reinterpret_cast<rocDataType **>(y);
-                ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, (int)n[i], (rocDataType *)&alpha[i],
+                rocblas_native_func(func, err, handle, (int)n[i], (rocDataType *)&alpha[i],
                                         x_ + offset, (int)incx[i], y_ + offset, (int)incy[i],
                                         (int)group_size[i]);
                 offset += group_size[i];
@@ -643,7 +643,7 @@ inline sycl::event axpy_batch(Func func, sycl::queue &queue, int64_t n, T alpha,
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, (rocDataType *)&alpha, x_, incx, stridex,
+            rocblas_native_func(func, err, handle, n, (rocDataType *)&alpha, x_, incx, stridex,
                                     y_, incy, stridey, batch_size);
         });
     });
@@ -684,7 +684,7 @@ inline sycl::event gemv_batch(Func func, sycl::queue &queue, transpose trans, in
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans), m, n,
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans), m, n,
                                     (rocDataType *)&alpha, a_, lda, stridea, x_, incx, stridex,
                                     (rocDataType *)&beta, y_, incy, stridey, batch_size);
         });
@@ -731,7 +731,7 @@ inline sycl::event gemv_batch(Func func, sycl::queue &queue, transpose *trans, i
                 auto **a_ = reinterpret_cast<const rocDataType **>(a);
                 auto **x_ = reinterpret_cast<const rocDataType **>(x);
                 auto **y_ = reinterpret_cast<rocDataType **>(y);
-                ROCBLAS_ERROR_FUNC_SYNC(
+                rocblas_native_func(
                     func, err, handle, get_rocblas_operation(trans[i]), (int)m[i], (int)n[i],
                     (rocDataType *)&alpha[i], a_ + offset, (int)lda[i], x_ + offset, (int)incx[i],
                     (rocDataType *)&beta[i], y_ + offset, (int)incy[i], (int)group_size[i]);
@@ -776,7 +776,7 @@ inline sycl::event dgmm_batch(Func func, sycl::queue &queue, side left_right, in
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right), m, n, a_,
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right), m, n, a_,
                                     lda, stridea, x_, incx, stridex, c_, ldc, stridec, batch_size);
         });
     });
@@ -821,7 +821,7 @@ inline sycl::event dgmm_batch(Func func, sycl::queue &queue, side *left_right, i
                 auto **a_ = reinterpret_cast<const rocDataType **>(a);
                 auto **x_ = reinterpret_cast<const rocDataType **>(x);
                 auto **c_ = reinterpret_cast<rocDataType **>(c);
-                ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right[i]),
+                rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right[i]),
                                         (int)m[i], (int)n[i], a_ + offset, (int)lda[i], x_ + offset,
                                         (int)incx[i], c_ + offset, (int)ldc[i], (int)group_size[i]);
                 offset += group_size[i];
@@ -873,7 +873,7 @@ inline sycl::event gemm_batch_strided_usm_impl(sycl::queue &queue, transpose tra
             auto b_ = reinterpret_cast<const rocTypeB *>(b);
             auto c_ = reinterpret_cast<rocTypeC *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(rocblas_gemm_strided_batched_ex, err, handle,
+            rocblas_native_func(rocblas_gemm_strided_batched_ex, err, handle,
                                     get_rocblas_operation(transa), get_rocblas_operation(transb), m,
                                     n, k, &alpha, a_, get_rocblas_datatype<rocTypeA>(), lda,
                                     stridea, b_, get_rocblas_datatype<rocTypeB>(), ldb, strideb,
@@ -953,7 +953,7 @@ inline sycl::event gemm_batch_usm_impl(sycl::queue &queue, transpose *transa, tr
                 auto **a_ = reinterpret_cast<const rocTypeA **>(a);
                 auto **b_ = reinterpret_cast<const rocTypeB **>(b);
                 auto **c_ = reinterpret_cast<rocTypeC **>(c);
-                ROCBLAS_ERROR_FUNC_SYNC(
+                rocblas_native_func(
                     rocblas_gemm_batched_ex, err, handle, get_rocblas_operation(transa[i]),
                     get_rocblas_operation(transb[i]), (int)m[i], (int)n[i], (int)k[i], &alpha[i],
                     a_ + offset, get_rocblas_datatype<rocTypeA>(), (int)lda[i], b_ + offset,
@@ -1025,7 +1025,7 @@ inline sycl::event trsm_batch(Func func, sycl::queue &queue, side left_right, up
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto b_ = reinterpret_cast<rocDataType *>(b);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, stridea, b_, ldb, strideb,
@@ -1072,7 +1072,7 @@ inline sycl::event trsm_batch(Func func, sycl::queue &queue, side *left_right, u
             for (int64_t i = 0; i < group_count; i++) {
                 auto **a_ = reinterpret_cast<const rocDataType **>(a);
                 auto **b_ = reinterpret_cast<rocDataType **>(b);
-                ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right[i]),
+                rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right[i]),
                                         get_rocblas_fill_mode(upper_lower[i]),
                                         get_rocblas_operation(trans[i]),
                                         get_rocblas_diag_type(unit_diag[i]), (int)m[i], (int)n[i],
@@ -1123,7 +1123,7 @@ inline sycl::event syrk_batch(Func func, sycl::queue &queue, uplo *upper_lower, 
             for (int64_t i = 0; i < group_count; i++) {
                 auto **a_ = reinterpret_cast<const rocDataType **>(a);
                 auto **c_ = reinterpret_cast<rocDataType **>(c);
-                ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower[i]),
+                rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower[i]),
                                         get_rocblas_operation(trans[i]), (int)n[i], (int)k[i],
                                         (rocDataType *)&alpha[i], a_ + offset, (int)lda[i],
                                         (rocDataType *)&beta[i], c_ + offset, (int)ldc[i],
@@ -1168,7 +1168,7 @@ inline sycl::event syrk_batch(Func func, sycl::queue &queue, uplo upper_lower, t
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, stridea, (rocDataType *)&beta, c_, ldc, stridec,
                                     batch_size);
@@ -1216,7 +1216,7 @@ inline sycl::event omatcopy_batch(Func func, sycl::queue &queue, transpose trans
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto b_ = reinterpret_cast<rocDataType *>(b);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans),
                                     get_rocblas_operation(trans), new_m, new_n,
                                     (rocDataType *)&alpha, a_, lda, stridea, (rocDataType *)&beta,
                                     nullptr, lda, stridea, b_, ldb, strideb, batch_size);
@@ -1286,7 +1286,7 @@ inline sycl::event omatadd_batch(Func func, sycl::queue &queue, transpose transa
             auto b_ = reinterpret_cast<const rocDataType *>(b);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(transa),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(transa),
                                     get_rocblas_operation(transb), m, n, (rocDataType *)&alpha, a_,
                                     lda, stridea, (rocDataType *)&beta, b_, ldb, strideb, c_, ldc,
                                     stridec, batch_size);
@@ -1338,7 +1338,7 @@ inline sycl::event omatcopy_batch(Func func, sycl::queue &queue, transpose *tran
                 const auto new_m = trans[i] == oneapi::mkl::transpose::nontrans ? m[i] : n[i];
                 const auto new_n = trans[i] == oneapi::mkl::transpose::nontrans ? n[i] : m[i];
 
-                ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans[i]),
+                rocblas_native_func(func, err, handle, get_rocblas_operation(trans[i]),
                                         get_rocblas_operation(trans[i]), (int)new_m, (int)new_n,
                                         (rocDataType *)&alpha[i], a_ + offset, (int)lda[i],
                                         (rocDataType *)&beta, nullptr, (int)lda[i], b_ + offset,

--- a/src/blas/backends/rocblas/rocblas_helper.hpp
+++ b/src/blas/backends/rocblas/rocblas_helper.hpp
@@ -173,6 +173,16 @@ public:
     hipError_t hip_err;                                                    \
     HIP_ERROR_FUNC(hipStreamSynchronize, hip_err, currentStreamId);
 
+template <class Func, class... Types>
+inline void rocblas_native_func(Func func, rocblas_status err,
+                               rocblas_handle handle, Types... args) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+  ROCBLAS_ERROR_FUNC(func, err, handle, args...)
+#else
+  ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, args...)
+#endif
+};
+
 inline rocblas_operation get_rocblas_operation(oneapi::mkl::transpose trn) {
     switch (trn) {
         case oneapi::mkl::transpose::nontrans: return rocblas_operation_none;

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -55,7 +55,7 @@ inline void asum(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &
             auto res_ = sc.get_mem<rocDataType2 *>(res_acc);
             rocblas_status err;
             // ASUM does not support negative index
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, std::abs(incx), res_);
+            rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -91,7 +91,7 @@ inline void scal(Func func, sycl::queue &queue, int64_t n, T1 a, sycl::buffer<T2
             auto x_ = sc.get_mem<rocDataType2 *>(x_acc);
             rocblas_status err;
             // SCAL does not support negative incx
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, (rocDataType1 *)&a, x_, std::abs(incx));
+            rocblas_native_func(func, err, handle, n, (rocDataType1 *)&a, x_, std::abs(incx));
         });
     });
 }
@@ -125,7 +125,7 @@ inline void axpy(Func func, sycl::queue &queue, int64_t n, T alpha, sycl::buffer
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, (rocDataType *)&alpha, x_, incx, y_,
+            rocblas_native_func(func, err, handle, n, (rocDataType *)&alpha, x_, incx, y_,
                                     incy);
         });
     });
@@ -190,7 +190,7 @@ inline void rotg(Func func, sycl::queue &queue, sycl::buffer<T1, 1> &a, sycl::bu
             auto c_ = sc.get_mem<rocDataType2 *>(c_acc);
             auto s_ = sc.get_mem<rocDataType1 *>(s_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, a_, b_, c_, s_);
+            rocblas_native_func(func, err, handle, a_, b_, c_, s_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -235,7 +235,7 @@ inline void rotm(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             auto param_ = sc.get_mem<rocDataType *>(param_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy, param_);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, param_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -270,7 +270,7 @@ inline void copy(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy);
         });
     });
 }
@@ -311,7 +311,7 @@ inline void dot(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x,
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             auto res_ = sc.get_mem<rocDataType *>(res_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy, res_);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, res_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -362,7 +362,7 @@ inline void rot(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &x
             auto x_ = sc.get_mem<rocDataType1 *>(x_acc);
             auto y_ = sc.get_mem<rocDataType1 *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy, (rocDataType2 *)&c,
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, (rocDataType2 *)&c,
                                     (rocDataType3 *)&s);
         });
     });
@@ -403,7 +403,7 @@ void sdsdot(sycl::queue &queue, int64_t n, float sb, sycl::buffer<float, 1> &x, 
             auto y_ = sc.get_mem<float *>(y_acc);
             auto res_ = sc.get_mem<float *>(res_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(rocblas_sdot, err, handle, n, x_, incx, y_, incy, res_);
+            rocblas_native_func(rocblas_sdot, err, handle, n, x_, incx, y_, incy, res_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -443,7 +443,7 @@ inline void rotmg(Func func, sycl::queue &queue, sycl::buffer<T, 1> &d1, sycl::b
             auto y1_ = sc.get_mem<rocDataType *>(y1_acc);
             auto param_ = sc.get_mem<rocDataType *>(param_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, d1_, d2_, x1_, y1_, param_);
+            rocblas_native_func(func, err, handle, d1_, d2_, x1_, y1_, param_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -494,7 +494,7 @@ inline void iamax(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &
             rocblas_status err;
             // For negative incx, iamax returns 0. This behaviour is similar to that of
             // reference netlib BLAS.
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, int_res_);
+            rocblas_native_func(func, err, handle, n, x_, incx, int_res_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -538,7 +538,7 @@ inline void swap(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &x
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy);
         });
     });
 }
@@ -587,7 +587,7 @@ inline void iamin(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T, 1> &
             rocblas_status err;
             // For negative incx, iamin returns 0. This behaviour is similar to that of
             // implemented as a reference IAMIN.
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, int_res_);
+            rocblas_native_func(func, err, handle, n, x_, incx, int_res_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -639,7 +639,7 @@ inline void nrm2(Func func, sycl::queue &queue, int64_t n, sycl::buffer<T1, 1> &
             auto res_ = sc.get_mem<rocDataType2 *>(res_acc);
             rocblas_status err;
             // NRM2 does not support negative index
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, std::abs(incx), res_);
+            rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
             // Higher level BLAS functions expect rocblas_pointer_mode_host
             // to be set, therfore we need to reset this to the default value
             // in order to avoid invalid memory accesses
@@ -680,7 +680,7 @@ inline sycl::event asum(Func func, sycl::queue &queue, int64_t n, const T1 *x, c
             auto res_ = reinterpret_cast<rocDataType2 *>(result);
             rocblas_status err;
             // ASUM does not support negative index
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, std::abs(incx), res_);
+            rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
@@ -716,7 +716,7 @@ inline sycl::event scal(Func func, sycl::queue &queue, int64_t n, T1 a, T2 *x, i
             auto x_ = reinterpret_cast<rocDataType2 *>(x);
             rocblas_status err;
             // SCAL does not support negative incx
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, (rocDataType1 *)&a, x_, std::abs(incx));
+            rocblas_native_func(func, err, handle, n, (rocDataType1 *)&a, x_, std::abs(incx));
         });
     });
 
@@ -752,7 +752,7 @@ inline sycl::event axpy(Func func, sycl::queue &queue, int64_t n, T alpha, const
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, (rocDataType *)&alpha, x_, incx, y_,
+            rocblas_native_func(func, err, handle, n, (rocDataType *)&alpha, x_, incx, y_,
                                     incy);
         });
     });
@@ -812,7 +812,7 @@ inline sycl::event rotg(Func func, sycl::queue &queue, T1 *a, T1 *b, T2 *c, T1 *
             auto c_ = reinterpret_cast<rocDataType2 *>(c);
             auto s_ = reinterpret_cast<rocDataType1 *>(s);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, a_, b_, c_, s_);
+            rocblas_native_func(func, err, handle, a_, b_, c_, s_);
         });
     });
 
@@ -847,7 +847,7 @@ inline sycl::event rotm(Func func, sycl::queue &queue, int64_t n, T *x, int64_t 
             auto y_ = reinterpret_cast<rocDataType *>(y);
             auto param_ = reinterpret_cast<rocDataType *>(param);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy, param_);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, param_);
         });
     });
 
@@ -879,7 +879,7 @@ inline sycl::event copy(Func func, sycl::queue &queue, int64_t n, const T *x, in
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy);
         });
     });
 
@@ -915,7 +915,7 @@ inline sycl::event dot(Func func, sycl::queue &queue, int64_t n, const T *x, con
             auto y_ = reinterpret_cast<const rocDataType *>(y);
             auto res_ = reinterpret_cast<rocDataType *>(result);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy, res_);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, res_);
         });
     });
 
@@ -959,7 +959,7 @@ inline sycl::event rot(Func func, sycl::queue &queue, int64_t n, T1 *x, const in
             auto x_ = reinterpret_cast<rocDataType1 *>(x);
             auto y_ = reinterpret_cast<rocDataType1 *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy, (rocDataType2 *)&c,
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy, (rocDataType2 *)&c,
                                     (rocDataType3 *)&s);
         });
     });
@@ -996,7 +996,7 @@ sycl::event sdsdot(sycl::queue &queue, int64_t n, float sb, const float *x, int6
             auto y_ = reinterpret_cast<const float *>(y);
             auto res_ = reinterpret_cast<float *>(result);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(rocblas_sdot, err, handle, n, x_, incx, y_, incy, res_);
+            rocblas_native_func(rocblas_sdot, err, handle, n, x_, incx, y_, incy, res_);
         });
     });
 
@@ -1021,7 +1021,7 @@ inline sycl::event rotmg(Func func, sycl::queue &queue, T *d1, T *d2, T *x1, T y
             auto y1_ = reinterpret_cast<const rocDataType *>(&y1);
             auto param_ = reinterpret_cast<rocDataType *>(param);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, d1_, d2_, x1_, y1_, param_);
+            rocblas_native_func(func, err, handle, d1_, d2_, x1_, y1_, param_);
         });
     });
 
@@ -1063,7 +1063,7 @@ inline sycl::event iamax(Func func, sycl::queue &queue, int64_t n, const T *x, c
             rocblas_status err;
             // For negative incx, iamax returns 0. This behaviour is similar to that of
             // reference iamax.
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, int_res_p_);
+            rocblas_native_func(func, err, handle, n, x_, incx, int_res_p_);
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
@@ -1100,7 +1100,7 @@ inline sycl::event swap(Func func, sycl::queue &queue, int64_t n, T *x, int64_t 
             auto x_ = reinterpret_cast<rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, y_, incy);
+            rocblas_native_func(func, err, handle, n, x_, incx, y_, incy);
         });
     });
 
@@ -1145,7 +1145,7 @@ inline sycl::event iamin(Func func, sycl::queue &queue, int64_t n, const T *x, c
             rocblas_status err;
             // For negative incx, iamin returns 0. This behaviour is similar to that of
             // implemented iamin.
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, incx, int_res_p_);
+            rocblas_native_func(func, err, handle, n, x_, incx, int_res_p_);
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });
@@ -1185,7 +1185,7 @@ inline sycl::event nrm2(Func func, sycl::queue &queue, int64_t n, const T1 *x, c
             auto res_ = reinterpret_cast<rocDataType2 *>(result);
             rocblas_status err;
             // NRM2 does not support negative index
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, n, x_, std::abs(incx), res_);
+            rocblas_native_func(func, err, handle, n, x_, std::abs(incx), res_);
             rocblas_set_pointer_mode(handle, rocblas_pointer_mode_host);
         });
     });

--- a/src/blas/backends/rocblas/rocblas_level2.cpp
+++ b/src/blas/backends/rocblas/rocblas_level2.cpp
@@ -99,7 +99,7 @@ inline void gemv(Func func, sycl::queue &queue, transpose trans, int64_t m, int6
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans), m, n,
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans), m, n,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -138,7 +138,7 @@ inline void gbmv(Func func, sycl::queue &queue, transpose trans, int64_t m, int6
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans), m, n, kl, ku,
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans), m, n, kl, ku,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -177,7 +177,7 @@ inline void ger(Func func, sycl::queue &queue, int64_t m, int64_t n, T alpha, sy
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, m, n, (rocDataType *)&alpha, x_, incx, y_,
+            rocblas_native_func(func, err, handle, m, n, (rocDataType *)&alpha, x_, incx, y_,
                                     incy, a_, lda);
         });
     });
@@ -217,7 +217,7 @@ inline void hbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -254,7 +254,7 @@ inline void hemv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -290,7 +290,7 @@ inline void her(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, Scal
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocScalarType *)&alpha, x_, incx, a_, lda);
         });
     });
@@ -326,7 +326,7 @@ inline void her2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_, lda);
         });
     });
@@ -362,7 +362,7 @@ inline void hpmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, x_, incx, (rocDataType *)&beta, y_,
                                     incy);
         });
@@ -397,7 +397,7 @@ inline void hpr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, Scal
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocScalarType *)&alpha, x_, incx, a_);
         });
     });
@@ -432,7 +432,7 @@ inline void hpr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_);
         });
     });
@@ -468,7 +468,7 @@ inline void sbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, int
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -505,7 +505,7 @@ inline void symv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -539,7 +539,7 @@ inline void syr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T al
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, a_, lda);
         });
     });
@@ -577,7 +577,7 @@ inline void syr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_, lda);
         });
     });
@@ -616,7 +616,7 @@ inline void spmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, x_, incx, (rocDataType *)&beta, y_,
                                     incy);
         });
@@ -650,7 +650,7 @@ inline void spr(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T al
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, a_);
         });
     });
@@ -685,7 +685,7 @@ inline void spr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t n, T a
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             auto y_ = sc.get_mem<rocDataType *>(y_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_);
         });
     });
@@ -719,7 +719,7 @@ inline void tbmv(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, k, a_, lda, x_, incx);
         });
@@ -756,7 +756,7 @@ inline void tbsv(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, k, a_, lda, x_, incx);
         });
@@ -792,7 +792,7 @@ inline void tpmv(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, x_, incx);
         });
@@ -827,7 +827,7 @@ inline void tpsv(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, x_, incx);
         });
@@ -863,7 +863,7 @@ inline void trmv(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, lda, x_, incx);
         });
@@ -899,7 +899,7 @@ inline void trsv(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto x_ = sc.get_mem<rocDataType *>(x_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, lda, x_, incx);
         });
@@ -937,7 +937,7 @@ inline sycl::event gemv(Func func, sycl::queue &queue, transpose trans, int64_t 
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans), m, n,
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans), m, n,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -978,7 +978,7 @@ inline sycl::event gbmv(Func func, sycl::queue &queue, transpose trans, int64_t 
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(trans), m, n, kl, ku,
+            rocblas_native_func(func, err, handle, get_rocblas_operation(trans), m, n, kl, ku,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -1019,7 +1019,7 @@ inline sycl::event ger(Func func, sycl::queue &queue, int64_t m, int64_t n, T al
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<const rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, m, n, (rocDataType *)&alpha, x_, incx, y_,
+            rocblas_native_func(func, err, handle, m, n, (rocDataType *)&alpha, x_, incx, y_,
                                     incy, a_, lda);
         });
     });
@@ -1059,7 +1059,7 @@ inline sycl::event hbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -1097,7 +1097,7 @@ inline sycl::event hemv(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -1135,7 +1135,7 @@ inline sycl::event her(Func func, sycl::queue &queue, uplo upper_lower, int64_t 
             auto a_ = reinterpret_cast<rocDataType *>(a);
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocScalarType *)&alpha, x_, incx, a_, lda);
         });
     });
@@ -1171,7 +1171,7 @@ inline sycl::event her2(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<const rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_, lda);
         });
     });
@@ -1208,7 +1208,7 @@ inline sycl::event hpmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, x_, incx, (rocDataType *)&beta, y_,
                                     incy);
         });
@@ -1246,7 +1246,7 @@ inline sycl::event hpr(Func func, sycl::queue &queue, uplo upper_lower, int64_t 
             auto a_ = reinterpret_cast<rocDataType *>(a);
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocScalarType *)&alpha, x_, incx, a_);
         });
     });
@@ -1282,7 +1282,7 @@ inline sycl::event hpr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<const rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_);
         });
     });
@@ -1319,7 +1319,7 @@ inline sycl::event sbmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n, k,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -1357,7 +1357,7 @@ inline sycl::event symv(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, lda, x_, incx, (rocDataType *)&beta,
                                     y_, incy);
         });
@@ -1394,7 +1394,7 @@ inline sycl::event syr(Func func, sycl::queue &queue, uplo upper_lower, int64_t 
             auto a_ = reinterpret_cast<rocDataType *>(a);
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, a_, lda);
         });
     });
@@ -1433,7 +1433,7 @@ inline sycl::event syr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<const rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_, lda);
         });
     });
@@ -1473,7 +1473,7 @@ inline sycl::event spmv(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, a_, x_, incx, (rocDataType *)&beta, y_,
                                     incy);
         });
@@ -1509,7 +1509,7 @@ inline sycl::event spr(Func func, sycl::queue &queue, uplo upper_lower, int64_t 
             auto a_ = reinterpret_cast<rocDataType *>(a);
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, a_);
         });
     });
@@ -1544,7 +1544,7 @@ inline sycl::event spr2(Func func, sycl::queue &queue, uplo upper_lower, int64_t
             auto x_ = reinterpret_cast<const rocDataType *>(x);
             auto y_ = reinterpret_cast<const rocDataType *>(y);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower), n,
                                     (rocDataType *)&alpha, x_, incx, y_, incy, a_);
         });
     });
@@ -1580,7 +1580,7 @@ inline sycl::event tbmv(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto x_ = reinterpret_cast<rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, k, a_, lda, x_, incx);
         });
@@ -1619,7 +1619,7 @@ inline sycl::event tbsv(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto x_ = reinterpret_cast<rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, k, a_, lda, x_, incx);
         });
@@ -1658,7 +1658,7 @@ inline sycl::event tpmv(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto x_ = reinterpret_cast<rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, x_, incx);
         });
@@ -1697,7 +1697,7 @@ inline sycl::event tpsv(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto x_ = reinterpret_cast<rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, x_, incx);
         });
@@ -1736,7 +1736,7 @@ inline sycl::event trmv(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto x_ = reinterpret_cast<rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, lda, x_, incx);
         });
@@ -1775,7 +1775,7 @@ inline sycl::event trsv(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto x_ = reinterpret_cast<rocDataType *>(x);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     n, a_, lda, x_, incx);
         });

--- a/src/blas/backends/rocblas/rocblas_level3.cpp
+++ b/src/blas/backends/rocblas/rocblas_level3.cpp
@@ -51,7 +51,7 @@ inline void gemm(Func func, sycl::queue &queue, transpose transa, transpose tran
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(transa),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(transa),
                                     get_rocblas_operation(transb), m, n, k, (rocDataType *)&alpha,
                                     a_, lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -98,7 +98,7 @@ inline void gemm_ex(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C
             auto b_ = sc.get_mem<rocDataType_B *>(b_acc);
             auto c_ = sc.get_mem<rocDataType_C *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(transa),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(transa),
                                     get_rocblas_operation(transb), m, n, k, (rocDataType_S *)&alpha,
                                     a_, DT_A, lda, b_, DT_B, ldb, (rocDataType_S *)&beta, c_, DT_C,
                                     ldc, c_, DT_C, ldc, CT, rocblas_gemm_algo_standard, 0, 0);
@@ -147,7 +147,7 @@ inline void symm(Func func, sycl::queue &queue, side left_right, uplo upper_lowe
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower), m, n, (rocDataType *)&alpha,
                                     a_, lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -187,7 +187,7 @@ inline void hemm(Func func, sycl::queue &queue, side left_right, uplo upper_lowe
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower), m, n, (rocDataType *)&alpha,
                                     a_, lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -223,7 +223,7 @@ inline void syrk(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, (rocDataType *)&beta, c_, ldc);
         });
@@ -261,7 +261,7 @@ inline void herk(Func func, sycl::queue &queue, uplo upper_lower, transpose tran
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocScalarType *)&alpha, a_,
                                     lda, (rocScalarType *)&beta, c_, ldc);
         });
@@ -298,7 +298,7 @@ inline void syr2k(Func func, sycl::queue &queue, uplo upper_lower, transpose tra
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -340,7 +340,7 @@ inline void her2k(Func func, sycl::queue &queue, uplo upper_lower, transpose tra
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             auto c_ = sc.get_mem<rocDataType *>(c_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, b_, ldb, (rocScalarType *)&beta, c_, ldc);
         });
@@ -382,12 +382,12 @@ inline void trmm(Func func, sycl::queue &queue, side left_right, uplo upper_lowe
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             rocblas_status err;
 #if ROCBLAS_VERSION_MAJOR >= 4
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb, b_, ldb);
 #else
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
@@ -427,7 +427,7 @@ inline void trsm(Func func, sycl::queue &queue, side left_right, uplo upper_lowe
             auto a_ = sc.get_mem<rocDataType *>(a_acc);
             auto b_ = sc.get_mem<rocDataType *>(b_acc);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
@@ -469,7 +469,7 @@ inline sycl::event gemm(Func func, sycl::queue &queue, transpose transa, transpo
             auto b_ = reinterpret_cast<const rocDataType *>(b);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(transa),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(transa),
                                     get_rocblas_operation(transb), m, n, k, (rocDataType *)&alpha,
                                     a_, lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -516,7 +516,7 @@ inline sycl::event gemm_ex(Func func, DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE
             auto b_ = reinterpret_cast<const rocDataType_B *>(b);
             auto c_ = reinterpret_cast<rocDataType_C *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_operation(transa),
+            rocblas_native_func(func, err, handle, get_rocblas_operation(transa),
                                     get_rocblas_operation(transb), m, n, k, (rocDataType_S *)&alpha,
                                     a_, DT_A, lda, b_, DT_B, ldb, (rocDataType_S *)&beta, c_, DT_C,
                                     ldc, c_, DT_C, ldc, CT, rocblas_gemm_algo_standard, 0, 0);
@@ -566,7 +566,7 @@ inline sycl::event symm(Func func, sycl::queue &queue, side left_right, uplo upp
             auto b_ = reinterpret_cast<const rocDataType *>(b);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower), m, n, (rocDataType *)&alpha,
                                     a_, lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -607,7 +607,7 @@ inline sycl::event hemm(Func func, sycl::queue &queue, side left_right, uplo upp
             auto b_ = reinterpret_cast<const rocDataType *>(b);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower), m, n, (rocDataType *)&alpha,
                                     a_, lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -645,7 +645,7 @@ inline sycl::event syrk(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, (rocDataType *)&beta, c_, ldc);
         });
@@ -686,7 +686,7 @@ inline sycl::event herk(Func func, sycl::queue &queue, uplo upper_lower, transpo
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocScalarType *)&alpha, a_,
                                     lda, (rocScalarType *)&beta, c_, ldc);
         });
@@ -726,7 +726,7 @@ inline sycl::event syr2k(Func func, sycl::queue &queue, uplo upper_lower, transp
             auto b_ = reinterpret_cast<const rocDataType *>(b);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, b_, ldb, (rocDataType *)&beta, c_, ldc);
         });
@@ -769,7 +769,7 @@ inline sycl::event her2k(Func func, sycl::queue &queue, uplo upper_lower, transp
             auto b_ = reinterpret_cast<const rocDataType *>(b);
             auto c_ = reinterpret_cast<rocDataType *>(c);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_fill_mode(upper_lower),
+            rocblas_native_func(func, err, handle, get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), n, k, (rocDataType *)&alpha, a_,
                                     lda, b_, ldb, (rocScalarType *)&beta, c_, ldc);
         });
@@ -813,12 +813,12 @@ inline sycl::event trmm(Func func, sycl::queue &queue, side left_right, uplo upp
             auto b_ = reinterpret_cast<rocDataType *>(b);
             rocblas_status err;
 #if ROCBLAS_VERSION_MAJOR >= 4
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb, b_, ldb);
 #else
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);
@@ -860,7 +860,7 @@ inline sycl::event trsm(Func func, sycl::queue &queue, side left_right, uplo upp
             auto a_ = reinterpret_cast<const rocDataType *>(a);
             auto b_ = reinterpret_cast<rocDataType *>(b);
             rocblas_status err;
-            ROCBLAS_ERROR_FUNC_SYNC(func, err, handle, get_rocblas_side_mode(left_right),
+            rocblas_native_func(func, err, handle, get_rocblas_side_mode(left_right),
                                     get_rocblas_fill_mode(upper_lower),
                                     get_rocblas_operation(trans), get_rocblas_diag_type(unit_diag),
                                     m, n, (rocDataType *)&alpha, a_, lda, b_, ldb);

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -62,7 +62,11 @@ static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
 #else
 template <typename H, typename F>
 static inline void host_task_internal(H &cgh, sycl::queue queue, F f) {
+#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+    cgh.ext_codeplay_enqueue_native_command([f, queue](sycl::interop_handle ih){
+#else
     cgh.host_task([f, queue](sycl::interop_handle ih) {
+#endif
         auto sc = RocblasScopedContextHandler(queue, ih);
         f(sc);
     });


### PR DESCRIPTION
This makes use of the enqueue_native_command dpc++ extension if it is available. This improves performance and integrates correctly with the dpc++ scheduler.

This matches very closely to the cublas impl from https://github.com/oneapi-src/oneMKL/pull/572
Please see the description of  https://github.com/oneapi-src/oneMKL/pull/572 for further details.

tests:

[test_main_blas_ct.txt](https://github.com/user-attachments/files/17257236/test_main_blas_ct.txt)
[test_main_blas_rt.txt](https://github.com/user-attachments/files/17257238/test_main_blas_rt.txt)
