### PR TITLE
[SPARSE] Fix oneMKL name usages in comments

### DIFF
--- a/include/oneapi/mkl/sparse_blas/types.hpp
+++ b/include/oneapi/mkl/sparse_blas/types.hpp
@@ -26,7 +26,7 @@
 #include "detail/operation_types.hpp"
 
 /**
- * @file Include and define the sparse types that are common between close-source MKL API and oneMKL API.
+ * @file Include and define the sparse types that are common between Intel(R) oneMKL API and oneMKL interfaces API.
 */
 
 namespace oneapi {

--- a/src/sparse_blas/backends/mkl_common/mkl_handles.hpp
+++ b/src/sparse_blas/backends/mkl_common/mkl_handles.hpp
@@ -61,7 +61,7 @@ struct dense_matrix_handle : public detail::generic_dense_matrix_handle<void*> {
 namespace oneapi::mkl::sparse::detail {
 
 /**
- * Internal sparse_matrix_handle type for oneMKL backends.
+ * Internal sparse_matrix_handle type for MKLCPU and MKLGPU backends.
  * Here \p matrix_handle_t is the type of the backend's handle.
  * The user-facing incomplete type matrix_handle_t must be kept incomplete.
  * Internally matrix_handle_t is reinterpret_cast as

--- a/src/sparse_blas/backends/mkl_common/mkl_handles.hpp
+++ b/src/sparse_blas/backends/mkl_common/mkl_handles.hpp
@@ -61,7 +61,7 @@ struct dense_matrix_handle : public detail::generic_dense_matrix_handle<void*> {
 namespace oneapi::mkl::sparse::detail {
 
 /**
- * Internal sparse_matrix_handle type for MKL backends.
+ * Internal sparse_matrix_handle type for oneMKL backends.
  * Here \p matrix_handle_t is the type of the backend's handle.
  * The user-facing incomplete type matrix_handle_t must be kept incomplete.
  * Internally matrix_handle_t is reinterpret_cast as


### PR DESCRIPTION
# Description

This PR is a small fix of oneMKL name usages.

# Checklist

## All Submissions

- Do all unit tests pass locally? Only comments are updated.
- [X] Have you formatted the code using clang-format?