### PR TITLE
[CI] Enable clang-format check

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -13,7 +13,6 @@ Fixes # (GitHub issue)
 ## All Submissions
 
 - [ ] Do all unit tests pass locally? Attach a log.
-- [ ] Have you formatted the code using clang-format?
 
 ## New interfaces
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,6 +14,19 @@ env:
   PARALLEL: -j 2
 
 jobs:
+  format-checks:
+    runs-on: ubuntu-latest
+    name: clang-format check
+    steps:
+    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - uses: actions/setup-python@f677139bbe7f9c59b41e40162b753c062f5d49a3 # v5.2.0
+      with:
+        python-version: '3.10'
+        cache: 'pip'
+    - name: Install pre-commit
+      run: pip install pre-commit
+    - name: Run clang-format check
+      run: pre-commit run --all-files --show-diff-on-failure --color always
   unit-tests:
     runs-on: ubuntu-latest
     # One runner for each domain

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+
+- repo: https://github.com/pre-commit/mirrors-clang-format
+  rev: v19.1.0
+  hooks:
+  - id: clang-format
+    files: \.(c|cxx|cpp|h|hxx|hpp)$
+    exclude: ^deps/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,16 @@ The general principle is to follow the style of existing/surrounding code. If yo
 ```sh
 clang-format -style=file -i foo.cpp
 ```
-This formats code using the `_clang_format` file found in the oneMKL top-level directory.
+This formats code using the `_clang_format` file found in the oneMKL top-level directory. The version of `clang-format` is specified in [`.pre-commit-config.yaml`](https://github.com/oneapi-src/oneMKL/blob/develop/.pre-commit-config.yaml). Alternatively, you can install and run `pre-commit`, which will install the specified `clang-format` version automatically:
+```sh
+python3 -m venv <venv-name>
+source <venv-name>/bin/activate
+pip install pre-commit
+cd <path-to-onemkl>
+pre-commit run --all-files
+deactivate
+```
+By default, `pre-commit` caches data in `~/.cache/pre-commit`. You can set `PRE_COMMIT_HOME` to use another location.
 
 
 ### GN: General Naming

--- a/scripts/generate_backend_api.py
+++ b/scripts/generate_backend_api.py
@@ -33,7 +33,7 @@ def usage(err = None):
         print('error: %s' % err)
     print('''\
 Script to generate backend library header based on base_header.h
-Note: requires clang-format 9.0.0 tool to be installed
+Note: requires clang-format tool to be installed
 Usage:
 
     {script} <path/to/base_header.hpp> <path/to/backend_include.hpp> <namespace>

--- a/scripts/generate_ct_instant.py
+++ b/scripts/generate_ct_instant.py
@@ -33,7 +33,7 @@ def usage(err = None):
         print('error: %s' % err)
     print('''\
 Script to generate CT API instantiations for backend based on general_ct_templates.hpp
-Note: requires clang-format 9.0.0 tool to be installed
+Note: requires clang-format tool to be installed
 Usage:
 
     {script} <path/to/general_ct_templates.hpp> <path/to/out_ct_header.hpp> <path/to/backend_include.hpp> <backend> <namespace>

--- a/scripts/generate_ct_templates.py
+++ b/scripts/generate_ct_templates.py
@@ -33,7 +33,7 @@ def usage(err = None):
         print('error: %s' % err)
     print('''\
 Script to generate header file for templated compile-time API based on base_header.h
-Note: requires clang-format 9.0.0 tool to be installed
+Note: requires clang-format tool to be installed
 Usage:
 
     {script} <path/to/base_header.hpp> <path/to/out_headername.hpp>

--- a/scripts/generate_wrappers.py
+++ b/scripts/generate_wrappers.py
@@ -33,7 +33,7 @@ def usage(err = None):
         print('error: %s' % err)
     print('''\
 Script to generate blank wrappers and pointers table based on header.hpp
-Note: requires clang-format 9.0.0 tool
+Note: requires clang-format tool
 Usage:
 
     {script} <path/to/header.hpp> <path/to/table.hpp> <path/to/out_wrappers.cpp> <libname>


### PR DESCRIPTION
# Description

According to the discussion in issue #580, this PR adds a job in CI to check code formatting using `pre-commit` with clang-format v19.1.0.

This PR will be rebased after [PR #594](https://github.com/oneapi-src/oneMKL/pull/594) is merged. We should have a green clang-format check then.

Fixes #580

# Checklist

## All Submissions

- Do all unit tests pass locally? No changes that affect tests.
- Have you formatted the code using clang-format? N/A
