### PR TITLE
[cublas][curand][cusolver] Fix OpenCL include dir hint

### DIFF
--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -26,6 +26,7 @@ HINTS
 ${OPENCL_INCLUDE_DIR}
 ${SYCL_BINARY_DIR}/../include/sycl/
 ${SYCL_BINARY_DIR}/../../include/sycl/
+${SYCL_BINARY_DIR}/../include/
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)

--- a/cmake/FindcuRAND.cmake
+++ b/cmake/FindcuRAND.cmake
@@ -66,6 +66,7 @@ find_path(OPENCL_INCLUDE_DIR CL/cl.h OpenCL/cl.h
 HINTS 
 ${OPENCL_INCLUDE_DIR}
 ${SYCL_BINARY_DIR}/../include/sycl/
+${SYCL_BINARY_DIR}/../include/
 )
 endif()
 

--- a/cmake/FindcuSOLVER.cmake
+++ b/cmake/FindcuSOLVER.cmake
@@ -25,6 +25,7 @@ find_path(OPENCL_INCLUDE_DIR CL/cl.h OpenCL/cl.h
 HINTS 
 ${OPENCL_INCLUDE_DIR}
 ${SYCL_BINARY_DIR}/../include/sycl/
+${SYCL_BINARY_DIR}/../include/
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)


### PR DESCRIPTION
In recent versions of DPC++ the CL headers go in `include` instead of `include/sycl`. So this patch fixes finding the OpenCL headers. Keep the hints for the previous path to still support older version.