### PR TITLE
[README] clarify spec changes in ratification process

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ contributors as reviewers to the PR.
 4. Organize offline review or/and bring the RFC to [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), [UXL Foundation Open Source Working Group](https://lists.uxlfoundation.org/g/open-source-wg), or any other related forums in order to collect feedback.
     * It's recommended to keep all feedback as part of PR review, so it also
 will be documented in one place
-5. If changes affect API defined by [oneMKL specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/) the design document must be reviewed by [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG) and contributed to [oneAPI specification](https://github.com/uxlfoundation/oneAPI-spec), and only after it the proposed changes can be implemented in this project.
+5. If changes affect API defined by [oneMKL specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/) the related part of the design document must be converted to oneAPI specification RFC (as a new [issue](https://github.com/uxlfoundation/oneAPI-spec/issues) with \[RFC\] tag), reviewed by [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), and contributed to [oneAPI specification](https://github.com/uxlfoundation/oneAPI-spec), and only after it the proposed changes can be implemented in this project.
 6. Merge PR when it has all required approvals
     * It's recommended to add PR number to the commit message, so it will be easy
 to find the design discussion

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ contributors as reviewers to the PR.
 4. Organize offline review or/and bring the RFC to [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), [UXL Foundation Open Source Working Group](https://lists.uxlfoundation.org/g/open-source-wg), or any other related forums in order to collect feedback.
     * It's recommended to keep all feedback as part of PR review, so it also
 will be documented in one place
-5. If changes affect API defined by [oneMKL specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/) the related part of the design document must be converted to oneAPI specification RFC (as a new [issue](https://github.com/uxlfoundation/oneAPI-spec/issues) with \[RFC\] tag), reviewed by [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), and contributed to [oneAPI specification](https://github.com/uxlfoundation/oneAPI-spec), and only after it the proposed changes can be implemented in this project.
+5. If the changes affect the API defined by [oneMKL specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/) a new [issue](https://github.com/uxlfoundation/oneAPI-spec/issues) with the \[RFC\] tag must be created to describe the API changes. The specification RFC must be reviewed by [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), and only after it the proposed changes can be implemented in this project.
 6. Merge PR when it has all required approvals
     * It's recommended to add PR number to the commit message, so it will be easy
 to find the design discussion

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ contributors as reviewers to the PR.
 4. Organize offline review or/and bring the RFC to [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), [UXL Foundation Open Source Working Group](https://lists.uxlfoundation.org/g/open-source-wg), or any other related forums in order to collect feedback.
     * It's recommended to keep all feedback as part of PR review, so it also
 will be documented in one place
-5. If the changes affect the API defined by [oneMKL specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/) a new [issue](https://github.com/uxlfoundation/oneAPI-spec/issues) with the \[RFC\] tag must be created to describe the API changes. The specification RFC must be reviewed by [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), and only after it the proposed changes can be implemented in this project.
+5. If the changes affect the API defined by [oneMKL specification](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/latest/elements/onemkl/source/), a new [issue](https://github.com/uxlfoundation/oneAPI-spec/issues) with the \[RFC\] tag must be created to describe the API changes. The specification RFC must be reviewed by [UXL Foundation Math SIG forum](https://lists.uxlfoundation.org/g/Math-SIG), and only after it the proposed changes can be implemented in this project.
 6. Merge PR when it has all required approvals
     * It's recommended to add PR number to the commit message, so it will be easy
 to find the design discussion


### PR DESCRIPTION
# Description

PR adds some clarification about oneAPI spec related changes in the RFC ratification process.
The need for the clarification was discussed in https://github.com/uxlfoundation/oneAPI-spec/pull/561#discussion_r1765080857

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log. N/A
- [x] Have you formatted the code using clang-format? N/A
