### PR TITLE
[SPARSE] Turn matrix_view into an aggregate

### DIFF
--- a/include/oneapi/mkl/sparse_blas/matrix_view.hpp
+++ b/include/oneapi/mkl/sparse_blas/matrix_view.hpp
@@ -38,10 +38,6 @@ struct matrix_view {
     matrix_descr type_view = matrix_descr::general;
     uplo uplo_view = uplo::lower;
     diag diag_view = diag::nonunit;
-
-    matrix_view() = default;
-
-    matrix_view(matrix_descr type_view) : type_view(type_view) {}
 };
 
 } // namespace sparse

--- a/tests/unit_tests/sparse_blas/include/test_spmv.hpp
+++ b/tests/unit_tests/sparse_blas/include/test_spmv.hpp
@@ -128,8 +128,9 @@ void test_helper_with_format_with_transpose(
                          default_properties, no_reset_data, no_scalars_on_device),
         num_passed, num_skipped);
     // Lower triangular
-    oneapi::mkl::sparse::matrix_view triangular_A_view(
-        oneapi::mkl::sparse::matrix_descr::triangular);
+    oneapi::mkl::sparse::matrix_view triangular_A_view{
+        oneapi::mkl::sparse::matrix_descr::triangular
+    };
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test_functor_i32(dev, queue_properties, format, nrows_A, ncols_A, density_A_matrix,
                          index_zero, transpose_val, fp_one, fp_zero, default_alg, triangular_A_view,
@@ -143,8 +144,9 @@ void test_helper_with_format_with_transpose(
                          default_properties, no_reset_data, no_scalars_on_device),
         num_passed, num_skipped);
     // Lower triangular unit diagonal
-    oneapi::mkl::sparse::matrix_view triangular_unit_A_view(
-        oneapi::mkl::sparse::matrix_descr::triangular);
+    oneapi::mkl::sparse::matrix_view triangular_unit_A_view{
+        oneapi::mkl::sparse::matrix_descr::triangular
+    };
     triangular_unit_A_view.diag_view = oneapi::mkl::diag::unit;
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test_functor_i32(dev, queue_properties, format, nrows_A, ncols_A, density_A_matrix,
@@ -161,7 +163,7 @@ void test_helper_with_format_with_transpose(
                          no_scalars_on_device),
         num_passed, num_skipped);
     // Lower symmetric
-    oneapi::mkl::sparse::matrix_view symmetric_view(oneapi::mkl::sparse::matrix_descr::symmetric);
+    oneapi::mkl::sparse::matrix_view symmetric_view{ oneapi::mkl::sparse::matrix_descr::symmetric };
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test_functor_i32(dev, queue_properties, format, nrows_A, ncols_A, density_A_matrix,
                          index_zero, transpose_val, fp_one, fp_zero, default_alg, symmetric_view,
@@ -175,7 +177,7 @@ void test_helper_with_format_with_transpose(
                          default_properties, no_reset_data, no_scalars_on_device),
         num_passed, num_skipped);
     // Lower hermitian
-    oneapi::mkl::sparse::matrix_view hermitian_view(oneapi::mkl::sparse::matrix_descr::hermitian);
+    oneapi::mkl::sparse::matrix_view hermitian_view{ oneapi::mkl::sparse::matrix_descr::hermitian };
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test_functor_i32(dev, queue_properties, format, nrows_A, ncols_A, density_A_matrix,
                          index_zero, transpose_val, fp_one, fp_zero, default_alg, hermitian_view,

--- a/tests/unit_tests/sparse_blas/include/test_spsv.hpp
+++ b/tests/unit_tests/sparse_blas/include/test_spsv.hpp
@@ -58,9 +58,12 @@ void test_helper_with_format(testFunctorI32 test_functor_i32, testFunctorI64 tes
     oneapi::mkl::index_base index_zero = oneapi::mkl::index_base::zero;
     oneapi::mkl::sparse::spsv_alg default_alg = oneapi::mkl::sparse::spsv_alg::default_alg;
     oneapi::mkl::sparse::spsv_alg no_optimize_alg = oneapi::mkl::sparse::spsv_alg::no_optimize_alg;
-    oneapi::mkl::sparse::matrix_view default_A_view(oneapi::mkl::sparse::matrix_descr::triangular);
-    oneapi::mkl::sparse::matrix_view upper_A_view(oneapi::mkl::sparse::matrix_descr::triangular);
-    upper_A_view.uplo_view = oneapi::mkl::uplo::upper;
+    oneapi::mkl::sparse::matrix_view default_A_view{
+        oneapi::mkl::sparse::matrix_descr::triangular
+    };
+    oneapi::mkl::sparse::matrix_view upper_A_view{ oneapi::mkl::sparse::matrix_descr::triangular,
+                                                   oneapi::mkl::uplo::upper,
+                                                   oneapi::mkl::diag::nonunit };
     bool no_reset_data = false;
     bool no_scalars_on_device = false;
 
@@ -99,20 +102,24 @@ void test_helper_with_format(testFunctorI32 test_functor_i32, testFunctorI64 tes
                          no_reset_data, no_scalars_on_device),
         num_passed, num_skipped);
     // Test lower triangular unit diagonal matrix
-    oneapi::mkl::sparse::matrix_view triangular_unit_A_view(
-        oneapi::mkl::sparse::matrix_descr::triangular);
-    triangular_unit_A_view.diag_view = oneapi::mkl::diag::unit;
+    oneapi::mkl::sparse::matrix_view lower_unit_A_view{
+        oneapi::mkl::sparse::matrix_descr::triangular, oneapi::mkl::uplo::lower,
+        oneapi::mkl::diag::unit
+    };
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test_functor_i32(dev, queue_properties, format, m, density_A_matrix, index_zero,
-                         transpose_val, alpha, default_alg, triangular_unit_A_view,
-                         default_properties, no_reset_data, no_scalars_on_device),
+                         transpose_val, alpha, default_alg, lower_unit_A_view, default_properties,
+                         no_reset_data, no_scalars_on_device),
         num_passed, num_skipped);
     // Test upper triangular unit diagonal matrix
-    triangular_unit_A_view.uplo_view = oneapi::mkl::uplo::upper;
+    oneapi::mkl::sparse::matrix_view upper_unit_A_view{
+        oneapi::mkl::sparse::matrix_descr::triangular, oneapi::mkl::uplo::upper,
+        oneapi::mkl::diag::unit
+    };
     EXPECT_TRUE_OR_FUTURE_SKIP(
         test_functor_i32(dev, queue_properties, format, m, density_A_matrix, index_zero,
-                         transpose_val, alpha, default_alg, triangular_unit_A_view,
-                         default_properties, no_reset_data, no_scalars_on_device),
+                         transpose_val, alpha, default_alg, upper_unit_A_view, default_properties,
+                         no_reset_data, no_scalars_on_device),
         num_passed, num_skipped);
     // Test non-default alpha
     EXPECT_TRUE_OR_FUTURE_SKIP(


### PR DESCRIPTION
# Description

This patch turns `sparse::matrix_view` into an aggregate having member initializers.

Fixes https://github.com/uxlfoundation/oneAPI-spec/issues/578

# Checklist

## All Submissions

- [*] Do all unit tests pass locally? Attach a log.  [test_cusparse.txt](https://github.com/user-attachments/files/17575847/test_cusparse.txt)


