### PR TITLE
[BLAS] Simplify CublasScopedContextHandler

### DIFF
--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -17,11 +17,6 @@
 *
 **************************************************************************/
 #include "cublas_scope_handle.hpp"
-#if __has_include(<sycl/detail/common.hpp>)
-#include <sycl/detail/common.hpp>
-#else
-#include <CL/sycl/detail/common.hpp>
-#endif
 
 namespace oneapi {
 namespace mkl {

--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -30,8 +30,7 @@ namespace cublas {
  * takes place if no other element in the container has a key equivalent to
  * the one being emplaced (keys in a map container are unique).
  */
-thread_local cublas_handle<CUdevice> CublasScopedContextHandler::handle_helper =
-    cublas_handle<CUdevice>{};
+thread_local cublas_handle CublasScopedContextHandler::handle_helper = cublas_handle{};
 
 CublasScopedContextHandler::CublasScopedContextHandler(sycl::interop_handle& ih) : ih(ih) {}
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -73,7 +73,6 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 
 class CublasScopedContextHandler {
     CUcontext original_;
-    sycl::context* placedContext_;
     sycl::interop_handle& ih;
     static thread_local cublas_handle<CUcontext> handle_helper;
     CUstream get_stream(const sycl::queue& queue);
@@ -82,7 +81,6 @@ class CublasScopedContextHandler {
 public:
     CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle& ih);
 
-    ~CublasScopedContextHandler() noexcept(false);
     /**
    * @brief get_handle: creates the handle by implicitly impose the advice
    * given by nvidia for creating a cublas_handle. (e.g. one cuStream per device

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -23,15 +23,6 @@
 #else
 #include <CL/sycl.hpp>
 #endif
-#if __has_include(<sycl/context.hpp>)
-#if __SYCL_COMPILER_VERSION <= 20220930
-#include <sycl/backend/cuda.hpp>
-#endif
-#include <sycl/context.hpp>
-#else
-#include <CL/sycl/backend/cuda.hpp>
-#include <CL/sycl/context.hpp>
-#endif
 
 #include <atomic>
 #include <memory>

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -33,18 +33,6 @@
 #include <CL/sycl/context.hpp>
 #endif
 
-// After Plugin Interface removal in DPC++ ur.hpp is the new include
-#if __has_include(<sycl/detail/ur.hpp>)
-#include <sycl/detail/ur.hpp>
-#ifndef ONEMKL_PI_INTERFACE_REMOVED
-#define ONEMKL_PI_INTERFACE_REMOVED
-#endif
-#elif __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
-#else
-#include <CL/sycl/detail/pi.hpp>
-#endif
-
 #include <atomic>
 #include <memory>
 #include <thread>
@@ -88,11 +76,7 @@ class CublasScopedContextHandler {
     sycl::context* placedContext_;
     bool needToRecover_;
     sycl::interop_handle& ih;
-#ifdef ONEMKL_PI_INTERFACE_REMOVED
-    static thread_local cublas_handle<ur_context_handle_t> handle_helper;
-#else
-    static thread_local cublas_handle<pi_context> handle_helper;
-#endif
+    static thread_local cublas_handle<CUcontext> handle_helper;
     CUstream get_stream(const sycl::queue& queue);
     sycl::context get_context(const sycl::queue& queue);
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -74,7 +74,6 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 class CublasScopedContextHandler {
     CUcontext original_;
     sycl::context* placedContext_;
-    bool needToRecover_;
     sycl::interop_handle& ih;
     static thread_local cublas_handle<CUcontext> handle_helper;
     CUstream get_stream(const sycl::queue& queue);

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -63,9 +63,8 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 **/
 
 class CublasScopedContextHandler {
-    CUcontext original_;
     sycl::interop_handle& ih;
-    static thread_local cublas_handle<CUcontext> handle_helper;
+    static thread_local cublas_handle<CUdevice> handle_helper;
     CUstream get_stream(const sycl::queue& queue);
     sycl::context get_context(const sycl::queue& queue);
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -62,7 +62,7 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 
 class CublasScopedContextHandler {
     sycl::interop_handle& ih;
-    static thread_local cublas_handle<CUdevice> handle_helper;
+    static thread_local cublas_handle handle_helper;
     CUstream get_stream(const sycl::queue& queue);
     sycl::context get_context(const sycl::queue& queue);
 

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -24,10 +24,8 @@
 #include <CL/sycl.hpp>
 #endif
 
-#include <atomic>
 #include <memory>
 #include <thread>
-#include <unordered_map>
 #include "cublas_helper.hpp"
 #include "cublas_handle.hpp"
 
@@ -69,7 +67,7 @@ class CublasScopedContextHandler {
     sycl::context get_context(const sycl::queue& queue);
 
 public:
-    CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle& ih);
+    CublasScopedContextHandler(sycl::interop_handle& ih);
 
     /**
    * @brief get_handle: creates the handle by implicitly impose the advice

--- a/src/blas/backends/cublas/cublas_scope_handle_hipsycl.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle_hipsycl.cpp
@@ -24,14 +24,14 @@ namespace mkl {
 namespace blas {
 namespace cublas {
 
-thread_local cublas_handle<int> CublasScopedContextHandler::handle_helper = cublas_handle<int>{};
+thread_local cublas_handle CublasScopedContextHandler::handle_helper = cublas_handle{};
 
 CublasScopedContextHandler::CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle& ih)
         : interop_h(ih) {}
 
 cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue& queue) {
     sycl::device device = queue.get_device();
-    int current_device = interop_h.get_native_device<sycl::backend::cuda>();
+    CUdevice current_device = interop_h.get_native_device<sycl::backend::cuda>();
     CUstream streamId = get_stream(queue);
     cublasStatus_t err;
     auto it = handle_helper.cublas_handle_mapper_.find(current_device);

--- a/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
@@ -25,7 +25,6 @@
 #endif
 #include <memory>
 #include <thread>
-#include <unordered_map>
 #include "cublas_helper.hpp"
 #include "cublas_handle.hpp"
 namespace oneapi {

--- a/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
@@ -59,7 +59,7 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 
 class CublasScopedContextHandler {
     sycl::interop_handle interop_h;
-    static thread_local cublas_handle<int> handle_helper;
+    static thread_local cublas_handle handle_helper;
     sycl::context get_context(const sycl::queue& queue);
     CUstream get_stream(const sycl::queue& queue);
 

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -35,18 +35,6 @@
 #else
 #include "cublas_scope_handle_hipsycl.hpp"
 
-// After Plugin Interface removal in DPC++ ur.hpp is the new include
-#if __has_include(<sycl/detail/ur.hpp>)
-#include <sycl/detail/ur.hpp>
-#ifndef ONEMKL_PI_INTERFACE_REMOVED
-#define ONEMKL_PI_INTERFACE_REMOVED
-#endif
-#elif __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
-#else
-#include <CL/sycl/detail/pi.hpp>
-#endif
-
 namespace sycl {
 using interop_handler = sycl::interop_handle;
 }

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -60,7 +60,7 @@ static inline void host_task_internal(H& cgh, sycl::queue queue, F f) {
 #else
     cgh.host_task([f, queue](sycl::interop_handle ih) {
 #endif
-        auto sc = CublasScopedContextHandler(queue, ih);
+        auto sc = CublasScopedContextHandler(ih);
         f(sc);
     });
 }


### PR DESCRIPTION
Nowadays we only use the cuda primary context in DPC++, hence we can refactor `CublasScopedContextHandler`.
 
 - Since now we only use the primary context which is unique to a device, we can change the 
   `unordered_map<context, handle>` to be `unordered_map<device, handle>`,
- I believe that the call to `sycl::detail::contextSetExtendedDeleter` is not necessary. It provides additional feature tying the lifetime of cublasHandle to the corresponding sycl queue but it makes the code very complicated (with atomics etc.) and uses the detail namespace which is not ideal.
- `cublas_handle.hpp` was modified such that it is not templated anymore. Both DPC++ and AdaptiveCpp versions use the same mapping so that could be simplified. Also, we need to set the correct context in the custom destructor in order to destroy cublas handles so the native type was necessary there.

Side note:
We can definitely remove the dependency on UR headers just by changing the templated types to the native types. 

[test_main_blas_rt.txt](https://github.com/user-attachments/files/17577366/test_main_blas_rt.txt)
[test_main_blas_ct.txt](https://github.com/user-attachments/files/17577367/test_main_blas_ct.txt)

