### PR TITLE
update oneapi to 2025

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -31,6 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     # One runner for each domain
     strategy:
+      fail-fast: false
       matrix:
         include:
         - config: portBLAS

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -77,13 +77,16 @@ jobs:
         # 64 bit int
         cmake ${SHARED_OPT} -DBUILD_INDEX64=on -B lapack/build64
         cmake --build lapack/build64 ${PARALLEL} --target install
-    - name: Install oneapi
+    - name: Install compiler
       if: steps.domain_check.outputs.result == 'true'
-      uses: rscohn2/setup-oneapi@2ad0cf6b74bc2426bdcee825cf88f9db719dd727 # v0.1.0
-      with:
-        components: |
-          icx@2024.1.0
-          mkl@2024.1.0
+      run: |
+        wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh
+        sudo bash intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh -s -a -s action install --eula accept
+    - name: Install MKL
+      if: steps.domain_check.outputs.result == 'true'
+      run: |
+        wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/79153e0f-74d7-45af-b8c2-258941adf58a/intel-onemkl-2025.0.0.940_offline.sh
+        sudo bash intel-onemkl-2025.0.0.940_offline.sh -s -a -s action install --eula accept
     - name: Configure/Build for a domain
       if: steps.domain_check.outputs.result == 'true'
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,7 +83,7 @@ jobs:
       run: |
         wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh
         sudo bash intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh -s -a -s --action install --eula accept
-    - name: Install MKL
+    - name: Install Intel oneMKL
       if: steps.domain_check.outputs.result == 'true'
       run: |
         wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/79153e0f-74d7-45af-b8c2-258941adf58a/intel-onemkl-2025.0.0.940_offline.sh

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,12 +81,12 @@ jobs:
       if: steps.domain_check.outputs.result == 'true'
       run: |
         wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh
-        sudo bash intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh -s -a -s action install --eula accept
+        sudo bash intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh -s -a -s --action install --eula accept
     - name: Install MKL
       if: steps.domain_check.outputs.result == 'true'
       run: |
         wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/79153e0f-74d7-45af-b8c2-258941adf58a/intel-onemkl-2025.0.0.940_offline.sh
-        sudo bash intel-onemkl-2025.0.0.940_offline.sh -s -a -s action install --eula accept
+        sudo bash intel-onemkl-2025.0.0.940_offline.sh -s -a -s --action install --eula accept
     - name: Configure/Build for a domain
       if: steps.domain_check.outputs.result == 'true'
       run: |

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,7 +81,7 @@ jobs:
     - name: Install compiler
       if: steps.domain_check.outputs.result == 'true'
       run: |
-        wget https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh
+        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh
         sudo bash intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh -s -a -s --action install --eula accept
     - name: Install Intel oneMKL
       if: steps.domain_check.outputs.result == 'true'


### PR DESCRIPTION
# Description

Update oneapi install to 2025. I removed setup-oneapi because I am not sure if I will be able to continue to maintain it. setup-oneapi used github caching to speed up install, but blas/lapack tests run for a long time and the acceleration doesn't matter so much. fft testing is much shorter so it will be slower.




