### PR TITLE
Update Supported Operating Systems in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,7 +437,7 @@ Supported compilers include:
 Backend | Supported Operating System
 :--- | :---
 x86 CPU    | Red Hat Enterprise Linux* 9 (RHEL* 9)
-Intel GPU  | Ubuntu 22.04 LTS
+Intel GPU  | Ubuntu 24.04 LTS
 NVIDIA GPU | Ubuntu 22.04 LTS
 
 #### Windows*


### PR DESCRIPTION
Ubuntu 24.04 was added to Supported Operating Systems for Intel GPU to reflect what was used in testing.



