### PR TITLE
[RNG] Fix warnings in device API and example

### DIFF
--- a/examples/rng/device/CMakeLists.txt
+++ b/examples/rng/device/CMakeLists.txt
@@ -60,6 +60,8 @@ foreach(rng_device_source ${RNG_DEVICE_SOURCES})
   )
 
   if(NOT ${ONEMKL_SYCL_IMPLEMENTATION} STREQUAL "hipsycl")
+    # set strict warning flags for rng device API examples
+    target_compile_options(example_${domain}_${rng_device_source} PUBLIC -Wall -Werror -Wextra -Wpedantic -Wunreachable-code -Wfloat-conversion -Wextra-semi -Wshadow)
     target_link_options(example_${domain}_${rng_device_source} PUBLIC -fsycl -fsycl-device-code-split=per_kernel)
   endif()
 

--- a/examples/rng/device/include/rng_example_helper.hpp
+++ b/examples/rng/device/include/rng_example_helper.hpp
@@ -35,7 +35,7 @@ auto get_multi_ptr(T acc) {
 #else
     return acc.get_pointer();
 #endif
-};
+}
 
 template <typename T, typename std::enable_if<!has_member_code_meta<T>::value>::type* = nullptr>
 auto get_multi_ptr(T acc) {
@@ -45,6 +45,6 @@ auto get_multi_ptr(T acc) {
 #else
     return acc.get_pointer();
 #endif
-};
+}
 
 #endif // _RNG_EXAMPLE_HELPER_HPP__

--- a/examples/rng/device/uniform.cpp
+++ b/examples/rng/device/uniform.cpp
@@ -109,7 +109,7 @@ int run_example(sycl::queue& queue) {
 
     int err = 0;
     Type res_host;
-    for (int i = 0; i < n; i++) {
+    for (std::size_t i = 0; i < n; i++) {
         res_host = oneapi::mkl::rng::device::generate(distr, engine);
         if (res_host != r_dev[i]) {
             std::cout << "error in " << i << " element " << res_host << " " << r_dev[i]

--- a/include/oneapi/mkl/rng/device/detail/beta_impl.hpp
+++ b/include/oneapi/mkl/rng/device/detail/beta_impl.hpp
@@ -364,9 +364,8 @@ protected:
                     flInv = RealType(1.0) / (q_ + flW);
                     flTmp[0] = flKoef1 * flInv;
                     flTmp[1] = flU1 * flU1 * flU2;
-                    for (int i = 0; i < 2; i++) {
-                        flTmp[i] = ln_wrapper(flTmp[i]);
-                    }
+                    flTmp[0] = ln_wrapper(flTmp[0]);
+                    flTmp[1] = ln_wrapper(flTmp[1]);
 
                     if (flKoef1 * flTmp[0] + flKoef3 * flV - log4<RealType>() >= flTmp[1]) {
                         z[i] = flW * flInv;

--- a/include/oneapi/mkl/rng/device/detail/uniform_impl.hpp
+++ b/include/oneapi/mkl/rng/device/detail/uniform_impl.hpp
@@ -140,7 +140,6 @@ protected:
                     return generate_single_int<FpType, OutType>(engine);
 
                 if constexpr (EngineType::vec_size == 1) {
-                    std::uint32_t res_1, res_2;
                     std::uint64_t res_64, leftover;
 
                     generate_leftover<EngineType>(
@@ -270,7 +269,6 @@ protected:
                     return res;
                 }
 
-                std::uint32_t res_1, res_2;
                 std::uint64_t res_64, leftover;
 
                 generate_leftover<EngineType>(


### PR DESCRIPTION
# Description
This PR fixes warnings with strict compilation flags for RNG device APIs

# Checklist

## All Submissions

- [x] Do all unit tests pass locally?

## Bug fixes

- [x] Have you added relevant regression tests? Compilation flags are added to device example (as a minimal start)

