### PR TITLE
cmake: Only set deprecated property when supported

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -44,7 +44,9 @@ function(add_deprecated_library target_name)
   # The INTERFACE IMPORTED target works like an alias which can have different properties
   add_library(deprecated_name INTERFACE IMPORTED)
   target_link_libraries(deprecated_name INTERFACE target_name)
-  set_target_properties(deprecated_name PROPERTIES DEPRECATION "${deprecated_name} target is deprecated, please use ${target_name} instead")
+  if(CMAKE_VERSION VERSION_GREATER_EQUAL "3.22.1")
+    set_target_properties(deprecated_name PROPERTIES DEPRECATION "${deprecated_name} target is deprecated, please use ${target_name} instead")
+  endif()
 endfunction()
 
 


### PR DESCRIPTION
# Description

CMake versions older than 3.22 do not supported setting the deprecated property on an `INTERFACE` target.
I have tested with CMake 3.22 and 3.13 locally.

Fixes https://github.com/uxlfoundation/oneMath/issues/619
