### PR TITLE
Fix include when including deprecated mkl.hpp

### DIFF
--- a/include/oneapi/mkl.hpp
+++ b/include/oneapi/mkl.hpp
@@ -31,6 +31,6 @@
 #include "oneapi/math/rng.hpp"
 #include "oneapi/math/sparse_blas.hpp"
 
-#include "namespace_alias.hpp"
+#include "mkl/namespace_alias.hpp"
 
 #endif // ONEMATH_MKL_HPP


### PR DESCRIPTION
# Description

Fix include path when using `mkl.hpp`. I have reproduced the issue with a small sample that uses `mkl.hpp`. This should fix the issue.

Fixes https://github.com/uxlfoundation/oneMath/issues/623

# Checklist

## All Submissions

- [N/A] Do all unit tests pass locally? (tests do not use mkl.hpp)
