### PR TITLE
[RNG][Device API] Added (u)int8_t and (u)int16_t types support for Uniform

### DIFF
--- a/include/oneapi/math/rng/device/detail/uniform_impl.hpp
+++ b/include/oneapi/math/rng/device/detail/uniform_impl.hpp
@@ -123,7 +123,8 @@ protected:
         OutType res;
         if constexpr (std::is_integral<Type>::value) {
             if constexpr (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
-                          std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>) {
+                          std::is_same_v<Type, std::int16_t> ||
+                          std::is_same_v<Type, std::uint16_t>) {
                 return generate_single_int<float, OutType>(engine);
             }
             else if constexpr (std::is_same_v<Type, std::int32_t> ||
@@ -248,7 +249,8 @@ protected:
         Type res;
         if constexpr (std::is_integral<Type>::value) {
             if constexpr (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
-                          std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>) {
+                          std::is_same_v<Type, std::int16_t> ||
+                          std::is_same_v<Type, std::uint16_t>) {
                 float res_fp =
                     engine.generate_single(static_cast<float>(a_), static_cast<float>(b_));
                 res_fp = sycl::floor(res_fp);

--- a/include/oneapi/math/rng/device/detail/uniform_impl.hpp
+++ b/include/oneapi/math/rng/device/detail/uniform_impl.hpp
@@ -122,8 +122,12 @@ protected:
                                       float>::type;
         OutType res;
         if constexpr (std::is_integral<Type>::value) {
-            if constexpr (std::is_same_v<Type, std::int32_t> ||
-                          std::is_same_v<Type, std::uint32_t>) {
+            if constexpr (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
+                          std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>) {
+                return generate_single_int<float, OutType>(engine);
+            }
+            else if constexpr (std::is_same_v<Type, std::int32_t> ||
+                               std::is_same_v<Type, std::uint32_t>) {
                 return generate_single_int<FpType, OutType>(engine);
             }
             else {
@@ -243,8 +247,16 @@ protected:
                                       float>::type;
         Type res;
         if constexpr (std::is_integral<Type>::value) {
-            if constexpr (std::is_same_v<Type, std::int32_t> ||
-                          std::is_same_v<Type, std::uint32_t>) {
+            if constexpr (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
+                          std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>) {
+                float res_fp =
+                    engine.generate_single(static_cast<float>(a_), static_cast<float>(b_));
+                res_fp = sycl::floor(res_fp);
+                res = static_cast<Type>(res_fp);
+                return res;
+            }
+            else if constexpr (std::is_same_v<Type, std::int32_t> ||
+                               std::is_same_v<Type, std::uint32_t>) {
                 FpType res_fp =
                     engine.generate_single(static_cast<FpType>(a_), static_cast<FpType>(b_));
                 res_fp = sycl::floor(res_fp);

--- a/include/oneapi/math/rng/device/detail/uniform_impl.hpp
+++ b/include/oneapi/math/rng/device/detail/uniform_impl.hpp
@@ -118,17 +118,15 @@ protected:
         using OutType = typename std::conditional<EngineType::vec_size == 1, Type,
                                                   sycl::vec<Type, EngineType::vec_size>>::type;
         using FpType =
-            typename std::conditional<std::is_same<Method, uniform_method::accurate>::value, double,
-                                      float>::type;
+            typename std::conditional<std::is_same<
+                !std::is_same_v<Method, uniform_method::accurate> ||
+                std::is_same_v<Type, std::int8_t> ||
+                std::is_same_v<Type, std::uint8_t> ||
+                std::is_same_v<Type, std::int16_t> ||
+                std::is_same_v<Type, std::uint16_t>, float, double>::type;
         OutType res;
         if constexpr (std::is_integral<Type>::value) {
-            if constexpr (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
-                          std::is_same_v<Type, std::int16_t> ||
-                          std::is_same_v<Type, std::uint16_t>) {
-                return generate_single_int<float, OutType>(engine);
-            }
-            else if constexpr (std::is_same_v<Type, std::int32_t> ||
-                               std::is_same_v<Type, std::uint32_t>) {
+            if constexpr (!std::is_same_v<Type, std::int64_t> && !std::is_same_v<Type, std::uint64_t>) {
                 return generate_single_int<FpType, OutType>(engine);
             }
             else {
@@ -244,21 +242,15 @@ protected:
     template <typename EngineType>
     Type generate_single(EngineType& engine) {
         using FpType =
-            typename std::conditional<std::is_same<Method, uniform_method::accurate>::value, double,
-                                      float>::type;
+            typename std::conditional<std::is_same<
+                !std::is_same_v<Method, uniform_method::accurate> ||
+                std::is_same_v<Type, std::int8_t> ||
+                std::is_same_v<Type, std::uint8_t> ||
+                std::is_same_v<Type, std::int16_t> ||
+                std::is_same_v<Type, std::uint16_t>, float, double>::type;
         Type res;
         if constexpr (std::is_integral<Type>::value) {
-            if constexpr (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
-                          std::is_same_v<Type, std::int16_t> ||
-                          std::is_same_v<Type, std::uint16_t>) {
-                float res_fp =
-                    engine.generate_single(static_cast<float>(a_), static_cast<float>(b_));
-                res_fp = sycl::floor(res_fp);
-                res = static_cast<Type>(res_fp);
-                return res;
-            }
-            else if constexpr (std::is_same_v<Type, std::int32_t> ||
-                               std::is_same_v<Type, std::uint32_t>) {
+            if constexpr (!std::is_same_v<Type, std::int64_t> && !std::is_same_v<Type, std::uint64_t>) {
                 FpType res_fp =
                     engine.generate_single(static_cast<FpType>(a_), static_cast<FpType>(b_));
                 res_fp = sycl::floor(res_fp);

--- a/include/oneapi/math/rng/device/detail/uniform_impl.hpp
+++ b/include/oneapi/math/rng/device/detail/uniform_impl.hpp
@@ -118,15 +118,15 @@ protected:
         using OutType = typename std::conditional<EngineType::vec_size == 1, Type,
                                                   sycl::vec<Type, EngineType::vec_size>>::type;
         using FpType =
-            typename std::conditional<std::is_same<
+            typename std::conditional<
                 !std::is_same_v<Method, uniform_method::accurate> ||
-                std::is_same_v<Type, std::int8_t> ||
-                std::is_same_v<Type, std::uint8_t> ||
-                std::is_same_v<Type, std::int16_t> ||
-                std::is_same_v<Type, std::uint16_t>, float, double>::type;
+                std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
+                std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>,
+                float, double>::type;
         OutType res;
         if constexpr (std::is_integral<Type>::value) {
-            if constexpr (!std::is_same_v<Type, std::int64_t> && !std::is_same_v<Type, std::uint64_t>) {
+            if constexpr (!std::is_same_v<Type, std::int64_t> &&
+                          !std::is_same_v<Type, std::uint64_t>) {
                 return generate_single_int<FpType, OutType>(engine);
             }
             else {
@@ -242,15 +242,15 @@ protected:
     template <typename EngineType>
     Type generate_single(EngineType& engine) {
         using FpType =
-            typename std::conditional<std::is_same<
+            typename std::conditional<
                 !std::is_same_v<Method, uniform_method::accurate> ||
-                std::is_same_v<Type, std::int8_t> ||
-                std::is_same_v<Type, std::uint8_t> ||
-                std::is_same_v<Type, std::int16_t> ||
-                std::is_same_v<Type, std::uint16_t>, float, double>::type;
+                std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
+                std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>,
+                float, double>::type;
         Type res;
         if constexpr (std::is_integral<Type>::value) {
-            if constexpr (!std::is_same_v<Type, std::int64_t> && !std::is_same_v<Type, std::uint64_t>) {
+            if constexpr (!std::is_same_v<Type, std::int64_t> &&
+                          !std::is_same_v<Type, std::uint64_t>) {
                 FpType res_fp =
                     engine.generate_single(static_cast<FpType>(a_), static_cast<FpType>(b_));
                 res_fp = sycl::floor(res_fp);

--- a/include/oneapi/math/rng/device/detail/uniform_impl.hpp
+++ b/include/oneapi/math/rng/device/detail/uniform_impl.hpp
@@ -117,12 +117,11 @@ protected:
                                   sycl::vec<Type, EngineType::vec_size>>::type {
         using OutType = typename std::conditional<EngineType::vec_size == 1, Type,
                                                   sycl::vec<Type, EngineType::vec_size>>::type;
-        using FpType =
-            typename std::conditional<
-                !std::is_same_v<Method, uniform_method::accurate> ||
+        using FpType = typename std::conditional<
+            !std::is_same_v<Method, uniform_method::accurate> ||
                 std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
                 std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>,
-                float, double>::type;
+            float, double>::type;
         OutType res;
         if constexpr (std::is_integral<Type>::value) {
             if constexpr (!std::is_same_v<Type, std::int64_t> &&
@@ -241,12 +240,11 @@ protected:
 
     template <typename EngineType>
     Type generate_single(EngineType& engine) {
-        using FpType =
-            typename std::conditional<
-                !std::is_same_v<Method, uniform_method::accurate> ||
+        using FpType = typename std::conditional<
+            !std::is_same_v<Method, uniform_method::accurate> ||
                 std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
                 std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>,
-                float, double>::type;
+            float, double>::type;
         Type res;
         if constexpr (std::is_integral<Type>::value) {
             if constexpr (!std::is_same_v<Type, std::int64_t> &&

--- a/include/oneapi/math/rng/device/distributions.hpp
+++ b/include/oneapi/math/rng/device/distributions.hpp
@@ -36,10 +36,10 @@ namespace oneapi::math::rng::device {
 // Supported types:
 //      float
 //      double
-//      std::int8_t>
-//      std::uint8_t>
-//      std::int16_t>
-//      std::uint16_t>
+//      std::int8_t
+//      std::uint8_t
+//      std::int16_t
+//      std::uint16_t
 //      std::int32_t
 //      std::uint32_t
 //      std::int64_t

--- a/include/oneapi/math/rng/device/distributions.hpp
+++ b/include/oneapi/math/rng/device/distributions.hpp
@@ -68,10 +68,8 @@ public:
                   "oneMath: rng/uniform: method is incorrect");
 
     static_assert(std::is_same<Type, float>::value || std::is_same<Type, double>::value ||
-                      std::is_same_v<Type, std::int8_t> ||
-                      std::is_same_v<Type, std::uint8_t> ||
-                      std::is_same_v<Type, std::int16_t> ||
-                      std::is_same_v<Type, std::uint16_t> ||
+                      std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
+                      std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t> ||
                       std::is_same<Type, std::int32_t>::value ||
                       std::is_same<Type, std::uint32_t>::value ||
                       std::is_same<Type, std::int64_t>::value ||
@@ -86,15 +84,17 @@ public:
             : detail::distribution_base<uniform<Type, Method>>(
                   Type(0.0),
                   std::is_integral<Type>::value
-                    ? ((std::is_same_v<Type, std::uint64_t> || std::is_same_v<Type, std::int64_t>)
-                        ? (std::numeric_limits<Type>::max)()
-                        : (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
-                           std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>)
-                            ? (std::numeric_limits<Type>::max)()
-                            : (std::is_same<Method, uniform_method::standard>::value
-                                ? (1 << 23)
-                                : (std::numeric_limits<Type>::max)()))
-                  : Type(1.0)) {}
+                      ? ((std::is_same_v<Type, std::uint64_t> || std::is_same_v<Type, std::int64_t>)
+                             ? (std::numeric_limits<Type>::max)()
+                         : (std::is_same_v<Type, std::int8_t> ||
+                            std::is_same_v<Type, std::uint8_t> ||
+                            std::is_same_v<Type, std::int16_t> ||
+                            std::is_same_v<Type, std::uint16_t>)
+                             ? (std::numeric_limits<Type>::max)()
+                             : (std::is_same<Method, uniform_method::standard>::value
+                                    ? (1 << 23)
+                                    : (std::numeric_limits<Type>::max)()))
+                      : Type(1.0)) {}
 
     explicit uniform(Type a, Type b) : detail::distribution_base<uniform<Type, Method>>(a, b) {}
     explicit uniform(const param_type& pt)
@@ -593,12 +593,12 @@ public:
 // Represents discrete Bernoulli random number distribution
 //
 // Supported types:
-//      std::uint32_t
-//      std::int32_t
-//      std::uint16_t
-//      std::int16_t
-//      std::uint8_t
 //      std::int8_t
+//      std::uint8_t
+//      std::int16_t
+//      std::uint16_t
+//      std::int32_t
+//      std::uint32_t
 //
 // Supported methods:
 //      oneapi::math::rng::bernoulli_method::icdf;

--- a/include/oneapi/math/rng/device/distributions.hpp
+++ b/include/oneapi/math/rng/device/distributions.hpp
@@ -36,8 +36,14 @@ namespace oneapi::math::rng::device {
 // Supported types:
 //      float
 //      double
+//      std::int8_t>
+//      std::uint8_t>
+//      std::int16_t>
+//      std::uint16_t>
 //      std::int32_t
 //      std::uint32_t
+//      std::int64_t
+//      std::uint64_t
 //
 // Supported methods:
 //      oneapi::math::rng::device::uniform_method::standard
@@ -46,7 +52,8 @@ namespace oneapi::math::rng::device {
 // Input arguments:
 //      a - left bound. 0.0 by default
 //      b - right bound. 1.0 by default (for std::(u)int32_t std::numeric_limits<std::int32_t>::max()
-//          is used for accurate method and 2^23 is used for standard method)
+//          is used for accurate method and 2^23 is used for standard method;
+//          for std::(u)int8, std::(u)int16, std::(u)int64_t are used std::numeric_limits<one_of_these_three_types>::max())
 //
 // Note: using (un)signed integer uniform distribution with uniform_method::standard method may
 // cause incorrect statistics of the produced random numbers (due to rounding error) if
@@ -61,6 +68,10 @@ public:
                   "oneMath: rng/uniform: method is incorrect");
 
     static_assert(std::is_same<Type, float>::value || std::is_same<Type, double>::value ||
+                      std::is_same_v<Type, std::int8_t> ||
+                      std::is_same_v<Type, std::uint8_t> ||
+                      std::is_same_v<Type, std::int16_t> ||
+                      std::is_same_v<Type, std::uint16_t> ||
                       std::is_same<Type, std::int32_t>::value ||
                       std::is_same<Type, std::uint32_t>::value ||
                       std::is_same<Type, std::int64_t>::value ||
@@ -75,12 +86,15 @@ public:
             : detail::distribution_base<uniform<Type, Method>>(
                   Type(0.0),
                   std::is_integral<Type>::value
-                      ? ((std::is_same_v<Type, std::uint64_t> || std::is_same_v<Type, std::int64_t>)
-                             ? (std::numeric_limits<Type>::max)()
-                             : (std::is_same<Method, uniform_method::standard>::value
-                                    ? (1 << 23)
-                                    : (std::numeric_limits<Type>::max)()))
-                      : Type(1.0)) {}
+                    ? ((std::is_same_v<Type, std::uint64_t> || std::is_same_v<Type, std::int64_t>)
+                        ? (std::numeric_limits<Type>::max)()
+                        : (std::is_same_v<Type, std::int8_t> || std::is_same_v<Type, std::uint8_t> ||
+                           std::is_same_v<Type, std::int16_t> || std::is_same_v<Type, std::uint16_t>)
+                            ? (std::numeric_limits<Type>::max)()
+                            : (std::is_same<Method, uniform_method::standard>::value
+                                ? (1 << 23)
+                                : (std::numeric_limits<Type>::max)()))
+                  : Type(1.0)) {}
 
     explicit uniform(Type a, Type b) : detail::distribution_base<uniform<Type, Method>>(a, b) {}
     explicit uniform(const param_type& pt)
@@ -581,6 +595,10 @@ public:
 // Supported types:
 //      std::uint32_t
 //      std::int32_t
+//      std::uint16_t
+//      std::int16_t
+//      std::uint8_t
+//      std::int8_t
 //
 // Supported methods:
 //      oneapi::math::rng::bernoulli_method::icdf;

--- a/include/oneapi/math/rng/device/distributions.hpp
+++ b/include/oneapi/math/rng/device/distributions.hpp
@@ -51,9 +51,9 @@ namespace oneapi::math::rng::device {
 //
 // Input arguments:
 //      a - left bound. 0.0 by default
-//      b - right bound. 1.0 by default (for std::(u)int32_t std::numeric_limits<std::int32_t>::max()
-//          is used for accurate method and 2^23 is used for standard method;
-//          for std::(u)int8, std::(u)int16, std::(u)int64_t are used std::numeric_limits<one_of_these_three_types>::max())
+//      b - right bound. 1.0 for floating point types.
+//          For integer types, 2^23 is used for std::(u)int32_t in the case of standard method,
+//          and std::numeric_limits<integer_type>::max() for other integer types.
 //
 // Note: using (un)signed integer uniform distribution with uniform_method::standard method may
 // cause incorrect statistics of the produced random numbers (due to rounding error) if

--- a/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
+++ b/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
@@ -188,6 +188,82 @@ struct statistics_device<oneapi::math::rng::device::uniform<Fp, Method>> {
 };
 
 template <typename Method>
+struct statistics_device<oneapi::math::rng::device::uniform<std::int8_t, Method>> {
+    template <typename AllocType>
+    bool check(const std::vector<std::int8_t, AllocType>& r,
+               const oneapi::math::rng::device::uniform<std::int8_t, Method>& distr) {
+        double tM, tD, tQ;
+        float a = distr.a();
+        float b = distr.b();
+
+        // Theoretical moments
+        tM = (a + b - 1.0) / 2.0;
+        tD = ((b - a) * (b - a) - 1.0) / 12.0;
+        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
+             (7.0 / 240.0);
+
+        return compare_moments(r, tM, tD, tQ);
+    }
+};
+
+template <typename Method>
+struct statistics_device<oneapi::math::rng::device::uniform<std::uint8_t, Method>> {
+    template <typename AllocType>
+    bool check(const std::vector<std::uint8_t, AllocType>& r,
+               const oneapi::math::rng::device::uniform<std::uint8_t, Method>& distr) {
+        double tM, tD, tQ;
+        float a = distr.a();
+        float b = distr.b();
+
+        // Theoretical moments
+        tM = (a + b - 1.0) / 2.0;
+        tD = ((b - a) * (b - a) - 1.0) / 12.0;
+        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
+             (7.0 / 240.0);
+
+        return compare_moments(r, tM, tD, tQ);
+    }
+};
+
+template <typename Method>
+struct statistics_device<oneapi::math::rng::device::uniform<std::int16_t, Method>> {
+    template <typename AllocType>
+    bool check(const std::vector<std::int16_t, AllocType>& r,
+               const oneapi::math::rng::device::uniform<std::int16_t, Method>& distr) {
+        double tM, tD, tQ;
+        float a = distr.a();
+        float b = distr.b();
+
+        // Theoretical moments
+        tM = (a + b - 1.0) / 2.0;
+        tD = ((b - a) * (b - a) - 1.0) / 12.0;
+        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
+             (7.0 / 240.0);
+
+        return compare_moments(r, tM, tD, tQ);
+    }
+};
+
+template <typename Method>
+struct statistics_device<oneapi::math::rng::device::uniform<std::uint16_t, Method>> {
+    template <typename AllocType>
+    bool check(const std::vector<std::uint16_t, AllocType>& r,
+               const oneapi::math::rng::device::uniform<std::uint16_t, Method>& distr) {
+        double tM, tD, tQ;
+        float a = distr.a();
+        float b = distr.b();
+
+        // Theoretical moments
+        tM = (a + b - 1.0) / 2.0;
+        tD = ((b - a) * (b - a) - 1.0) / 12.0;
+        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
+             (7.0 / 240.0);
+
+        return compare_moments(r, tM, tD, tQ);
+    }
+};
+
+template <typename Method>
 struct statistics_device<oneapi::math::rng::device::uniform<std::int32_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::int32_t, AllocType>& r,

--- a/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
+++ b/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
@@ -166,176 +166,111 @@ bool compare_moments(const std::vector<Fp, AllocType>& r, double tM, double tD, 
     return true;
 }
 
+template <typename Distribution, typename Fp, typename AllocType>
+bool calculate_and_compare_moments_uniform(Distribution distr, const std::vector<Fp, AllocType>& r) {
+    using ParamsType = typename std::conditional<std::is_integral<Fp>::value, double, Fp>::type;
+
+    double tM, tD, tQ;
+    ParamsType a = distr.a();
+    ParamsType b = distr.b();
+
+    // Theoretical moments
+    if constexpr (std::is_integral<Fp>::value) {
+        tM = (a + b - 1.0) / 2.0;
+        tD = ((b - a) * (b - a) - 1.0) / 12.0;
+        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
+            (7.0 / 240.0);
+    }
+    else {
+        tM = (b + a) / 2.0;
+        tD = ((b - a) * (b - a)) / 12.0;
+        tQ = ((b - a) * (b - a) * (b - a) * (b - a)) / 80.0;
+    }
+
+    return compare_moments(r, tM, tD, tQ);
+}
+
 template <typename Distribution>
 struct statistics_device {};
 
 template <typename Fp, typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<Fp, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<Fp, Method>> {
     template <typename AllocType>
     bool check(const std::vector<Fp, AllocType>& r,
-               const oneapi::math::rng::device::uniform<Fp, Method>& distr) {
-        double tM, tD, tQ;
-        Fp a = distr.a();
-        Fp b = distr.b();
-
-        // Theoretical moments
-        tM = (b + a) / 2.0;
-        tD = ((b - a) * (b - a)) / 12.0;
-        tQ = ((b - a) * (b - a) * (b - a) * (b - a)) / 80.0;
-
-        return compare_moments(r, tM, tD, tQ);
+               const oneapi::mkl::rng::device::uniform<Fp, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::int8_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::int8_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::int8_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::int8_t, Method>& distr) {
-        double tM, tD, tQ;
-        float a = distr.a();
-        float b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+               const oneapi::mkl::rng::device::uniform<std::int8_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::uint8_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint8_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::uint8_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::uint8_t, Method>& distr) {
-        double tM, tD, tQ;
-        float a = distr.a();
-        float b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+               const oneapi::mkl::rng::device::uniform<std::uint8_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::int16_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::int16_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::int16_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::int16_t, Method>& distr) {
-        double tM, tD, tQ;
-        float a = distr.a();
-        float b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+               const oneapi::mkl::rng::device::uniform<std::int16_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::uint16_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint16_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::uint16_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::uint16_t, Method>& distr) {
-        double tM, tD, tQ;
-        float a = distr.a();
-        float b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+               const oneapi::mkl::rng::device::uniform<std::uint16_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::int32_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::int32_t, Method>> {
     template <typename AllocType>
-    bool check(const std::vector<std::int32_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::int32_t, Method>& distr) {
-        double tM, tD, tQ;
-        double a = distr.a();
-        double b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+    bool check(const std::vector<int32_t, AllocType>& r,
+               const oneapi::mkl::rng::device::uniform<int32_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::uint32_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint32_t, Method>> {
     template <typename AllocType>
-    bool check(const std::vector<std::uint32_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::uint32_t, Method>& distr) {
-        double tM, tD, tQ;
-        double a = distr.a();
-        double b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+    bool check(const std::vector<uint32_t, AllocType>& r,
+               const oneapi::mkl::rng::device::uniform<uint32_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::int64_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::int64_t, Method>> {
     template <typename AllocType>
-    bool check(const std::vector<std::int64_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::int64_t, Method>& distr) {
-        double tM, tD, tQ;
-        double a = distr.a();
-        double b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+    bool check(const std::vector<int64_t, AllocType>& r,
+               const oneapi::mkl::rng::device::uniform<int64_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::math::rng::device::uniform<std::uint64_t, Method>> {
+struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint64_t, Method>> {
     template <typename AllocType>
-    bool check(const std::vector<std::uint64_t, AllocType>& r,
-               const oneapi::math::rng::device::uniform<std::uint64_t, Method>& distr) {
-        double tM, tD, tQ;
-        double a = distr.a();
-        double b = distr.b();
-
-        // Theoretical moments
-        tM = (a + b - 1.0) / 2.0;
-        tD = ((b - a) * (b - a) - 1.0) / 12.0;
-        tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-             (7.0 / 240.0);
-
-        return compare_moments(r, tM, tD, tQ);
+    bool check(const std::vector<uint64_t, AllocType>& r,
+               const oneapi::mkl::rng::device::uniform<uint64_t, Method>& distr) {
+        return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 

--- a/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
+++ b/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
@@ -167,7 +167,8 @@ bool compare_moments(const std::vector<Fp, AllocType>& r, double tM, double tD, 
 }
 
 template <typename Distribution, typename Fp, typename AllocType>
-bool calculate_and_compare_moments_uniform(Distribution distr, const std::vector<Fp, AllocType>& r) {
+bool calculate_and_compare_moments_uniform(Distribution distr,
+                                           const std::vector<Fp, AllocType>& r) {
     using ParamsType = typename std::conditional<std::is_integral<Fp>::value, double, Fp>::type;
 
     double tM, tD, tQ;
@@ -179,7 +180,7 @@ bool calculate_and_compare_moments_uniform(Distribution distr, const std::vector
         tM = (a + b - 1.0) / 2.0;
         tD = ((b - a) * (b - a) - 1.0) / 12.0;
         tQ = (((b - a) * (b - a)) * ((1.0 / 80.0) * (b - a) * (b - a) - (1.0 / 24.0))) +
-            (7.0 / 240.0);
+             (7.0 / 240.0);
     }
     else {
         tM = (b + a) / 2.0;
@@ -194,82 +195,82 @@ template <typename Distribution>
 struct statistics_device {};
 
 template <typename Fp, typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<Fp, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<Fp, Method>> {
     template <typename AllocType>
     bool check(const std::vector<Fp, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<Fp, Method>& distr) {
+               const oneapi::math::rng::device::uniform<Fp, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::int8_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::int8_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::int8_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<std::int8_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<std::int8_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint8_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::uint8_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::uint8_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<std::uint8_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<std::uint8_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::int16_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::int16_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::int16_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<std::int16_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<std::int16_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint16_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::uint16_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<std::uint16_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<std::uint16_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<std::uint16_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::int32_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::int32_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<int32_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<int32_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<int32_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint32_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::uint32_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<uint32_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<uint32_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<uint32_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::int64_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::int64_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<int64_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<int64_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<int64_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };
 
 template <typename Method>
-struct statistics_device<oneapi::mkl::rng::device::uniform<std::uint64_t, Method>> {
+struct statistics_device<oneapi::math::rng::device::uniform<std::uint64_t, Method>> {
     template <typename AllocType>
     bool check(const std::vector<uint64_t, AllocType>& r,
-               const oneapi::mkl::rng::device::uniform<uint64_t, Method>& distr) {
+               const oneapi::math::rng::device::uniform<uint64_t, Method>& distr) {
         return calculate_and_compare_moments_uniform(distr, r);
     }
 };

--- a/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
+++ b/tests/unit_tests/rng/device/include/rng_device_test_common.hpp
@@ -169,11 +169,9 @@ bool compare_moments(const std::vector<Fp, AllocType>& r, double tM, double tD, 
 template <typename Distribution, typename Fp, typename AllocType>
 bool calculate_and_compare_moments_uniform(Distribution distr,
                                            const std::vector<Fp, AllocType>& r) {
-    using ParamsType = typename std::conditional<std::is_integral<Fp>::value, double, Fp>::type;
-
     double tM, tD, tQ;
-    ParamsType a = distr.a();
-    ParamsType b = distr.b();
+    double a = distr.a();
+    double b = distr.b();
 
     // Theoretical moments
     if constexpr (std::is_integral<Fp>::value) {

--- a/tests/unit_tests/rng/device/moments/moments.cpp
+++ b/tests/unit_tests/rng/device/moments/moments.cpp
@@ -67,6 +67,92 @@ TEST_P(Philox4x32x10UniformStdDeviceMomentsTests, RealDoublePrecision) {
     EXPECT_TRUEORSKIP((test3(GetParam())));
 }
 
+/* Test small types (u)int8, (u)int16 only with uniform_method::standard since numbers are always generated
+   as single precision numbers */
+TEST_P(Philox4x32x10UniformStdDeviceMomentsTests, Integer8Precision) {
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<1>,
+                     oneapi::math::rng::device::uniform<
+                         std::int8_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<4>,
+                     oneapi::math::rng::device::uniform<
+                         std::int8_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<16>,
+                     oneapi::math::rng::device::uniform<
+                         std::int8_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test3;
+    EXPECT_TRUEORSKIP((test3(GetParam())));
+}
+
+TEST_P(Philox4x32x10UniformStdDeviceMomentsTests, UnsignedInteger8Precision) {
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<1>,
+                     oneapi::math::rng::device::uniform<
+                         std::uint8_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<4>,
+                     oneapi::math::rng::device::uniform<
+                         std::uint8_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<16>,
+                     oneapi::math::rng::device::uniform<
+                         std::uint8_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test3;
+    EXPECT_TRUEORSKIP((test3(GetParam())));
+}
+
+TEST_P(Philox4x32x10UniformStdDeviceMomentsTests, Integer16Precision) {
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<1>,
+                     oneapi::math::rng::device::uniform<
+                         std::int16_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<4>,
+                     oneapi::math::rng::device::uniform<
+                         std::int16_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<16>,
+                     oneapi::math::rng::device::uniform<
+                         std::int16_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test3;
+    EXPECT_TRUEORSKIP((test3(GetParam())));
+}
+
+TEST_P(Philox4x32x10UniformStdDeviceMomentsTests, UnsignedInteger16Precision) {
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<1>,
+                     oneapi::math::rng::device::uniform<
+                         std::uint16_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test1;
+    EXPECT_TRUEORSKIP((test1(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<4>,
+                     oneapi::math::rng::device::uniform<
+                         std::uint16_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test2;
+    EXPECT_TRUEORSKIP((test2(GetParam())));
+    rng_device_test<
+        moments_test<oneapi::math::rng::device::philox4x32x10<16>,
+                     oneapi::math::rng::device::uniform<
+                         std::uint16_t, oneapi::math::rng::device::uniform_method::standard>>>
+        test3;
+    EXPECT_TRUEORSKIP((test3(GetParam())));
+}
+
 TEST_P(Philox4x32x10UniformStdDeviceMomentsTests, IntegerPrecision) {
     rng_device_test<
         moments_test<oneapi::math::rng::device::philox4x32x10<1>,


### PR DESCRIPTION
# Description

At the DPNP team request support for the following small types was added for Uniform distribution:
- int8_t
- uint8_t
- int16_t
- uint16_t

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
