### PR TITLE
[BLAS] Let iamax/iamin accept index_base argument to align to the spec

### DIFF
--- a/include/oneapi/math/blas.hxx
+++ b/include/oneapi/math/blas.hxx
@@ -791,47 +791,55 @@ static inline void hpr2(sycl::queue& queue, uplo upper_lower, std::int64_t n,
 }
 
 static inline void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamax(get_device_id(queue), queue, n, x, incx, result);
+                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamax(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamax(get_device_id(queue), queue, n, x, incx, result);
+                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamax(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamax(sycl::queue& queue, std::int64_t n,
                          sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamax(get_device_id(queue), queue, n, x, incx, result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamax(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamax(sycl::queue& queue, std::int64_t n,
                          sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamax(get_device_id(queue), queue, n, x, incx, result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamax(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamin(get_device_id(queue), queue, n, x, incx, result);
+                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamin(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamin(get_device_id(queue), queue, n, x, incx, result);
+                         std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamin(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamin(sycl::queue& queue, std::int64_t n,
                          sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamin(get_device_id(queue), queue, n, x, incx, result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamin(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void iamin(sycl::queue& queue, std::int64_t n,
                          sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result) {
-    detail::iamin(get_device_id(queue), queue, n, x, incx, result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero) {
+    detail::iamin(get_device_id(queue), queue, n, x, incx, result, base);
 }
 
 static inline void nrm2(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
@@ -2948,57 +2956,65 @@ static inline sycl::event hpr2(sycl::queue& queue, uplo upper_lower, std::int64_
 
 static inline sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamax(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 
 static inline sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                                 std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {}) {
-    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, dependencies);
+    auto done = detail::iamin(get_device_id(queue), queue, n, x, incx, result, base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/armpl/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/armpl/blas_ct.hxx
@@ -618,25 +618,27 @@ void hpr(backend_selector<backend::armpl> selector, uplo upper_lower, std::int64
 }
 
 void iamin(backend_selector<backend::armpl> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::armpl> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::armpl> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::armpl> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::armpl> selector, uplo upper_lower, std::int64_t n,
@@ -1340,25 +1342,27 @@ void spr2(backend_selector<backend::armpl> selector, uplo upper_lower, std::int6
 }
 
 void iamax(backend_selector<backend::armpl> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::armpl> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::armpl> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::armpl> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::armpl> selector, std::int64_t n, sycl::buffer<float, 1>& x,
@@ -2548,34 +2552,34 @@ sycl::event hpr(backend_selector<backend::armpl> selector, uplo upper_lower, std
 }
 
 sycl::event iamin(backend_selector<backend::armpl> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::armpl> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::armpl> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::armpl> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
@@ -3760,34 +3764,34 @@ sycl::event spr2(backend_selector<backend::armpl> selector, uplo upper_lower, st
 }
 
 sycl::event iamax(backend_selector<backend::armpl> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::armpl> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::armpl> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::armpl> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::armpl::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                        dependencies);
+                                                        base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/blas_ct_backends.hxx
+++ b/include/oneapi/math/blas/detail/blas_ct_backends.hxx
@@ -396,19 +396,23 @@ static inline void hpr(backend_selector<backend::BACKEND> selector, uplo upper_l
 
 static inline void iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<float, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<double, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void gemm_batch(backend_selector<backend::BACKEND> selector, transpose transa,
                               transpose transb, std::int64_t m, std::int64_t n, std::int64_t k,
@@ -965,19 +969,23 @@ static inline void spr2(backend_selector<backend::BACKEND> selector, uplo upper_
 
 static inline void iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<float, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<double, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                          sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                         sycl::buffer<std::int64_t, 1>& result);
+                         sycl::buffer<std::int64_t, 1>& result,
+                         oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 static inline void trsm_batch(backend_selector<backend::BACKEND> selector, side left_right,
                               uplo upper_lower, transpose trans, diag unit_diag, std::int64_t m,
@@ -1775,20 +1783,24 @@ static inline sycl::event hpr(backend_selector<backend::BACKEND> selector, uplo 
 
 static inline sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const float* x, std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const double* x, std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const std::complex<float>* x, std::int64_t incx,
                                 std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event iamin(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const std::complex<double>* x, std::int64_t incx,
                                 std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event gemm_batch(backend_selector<backend::BACKEND> selector, transpose* transa,
@@ -2558,20 +2570,24 @@ static inline sycl::event spr2(backend_selector<backend::BACKEND> selector, uplo
 
 static inline sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const float* x, std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const double* x, std::int64_t incx, std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const std::complex<float>* x, std::int64_t incx,
                                 std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event iamax(backend_selector<backend::BACKEND> selector, std::int64_t n,
                                 const std::complex<double>* x, std::int64_t incx,
                                 std::int64_t* result,
+                                oneapi::math::index_base base = oneapi::math::index_base::zero,
                                 const std::vector<sycl::event>& dependencies = {});
 
 static inline sycl::event rotm(backend_selector<backend::BACKEND> selector, std::int64_t n,

--- a/include/oneapi/math/blas/detail/blas_loader.hxx
+++ b/include/oneapi/math/blas/detail/blas_loader.hxx
@@ -424,16 +424,20 @@ ONEMATH_EXPORT void gemm_bias(oneapi::math::device libkey, sycl::queue& queue, t
 
 ONEMATH_EXPORT void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<float, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 ONEMATH_EXPORT void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<double, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 ONEMATH_EXPORT void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 ONEMATH_EXPORT void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void hpmv(oneapi::math::device libkey, sycl::queue& queue, uplo upper_lower,
                          std::int64_t n, std::complex<float> alpha,
@@ -817,16 +821,20 @@ ONEMATH_EXPORT void hemv(oneapi::math::device libkey, sycl::queue& queue, uplo u
 
 ONEMATH_EXPORT void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<float, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 ONEMATH_EXPORT void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<double, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 ONEMATH_EXPORT void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 ONEMATH_EXPORT void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void sbmv(oneapi::math::device libkey, sycl::queue& queue, uplo upper_lower,
                          std::int64_t n, std::int64_t k, float alpha, sycl::buffer<float, 1>& a,
@@ -1705,16 +1713,20 @@ ONEMATH_EXPORT sycl::event hpr(oneapi::math::device libkey, sycl::queue& queue, 
 
 ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const float* x, std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const double* x, std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const std::complex<float>* x, std::int64_t incx,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  std::int64_t* result,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const std::complex<double>* x, std::int64_t incx,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  std::int64_t* result,
                                  const std::vector<sycl::event>& dependencies = {});
 
@@ -2248,17 +2260,21 @@ ONEMATH_EXPORT sycl::event hemv(oneapi::math::device libkey, sycl::queue& queue,
 
 ONEMATH_EXPORT sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const float* x, std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const double* x, std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const std::complex<float>* x, std::int64_t incx,
                                  std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const std::complex<double>* x, std::int64_t incx,
                                  std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event sbmv(oneapi::math::device libkey, sycl::queue& queue, uplo upper_lower,

--- a/include/oneapi/math/blas/detail/blas_loader.hxx
+++ b/include/oneapi/math/blas/detail/blas_loader.hxx
@@ -1721,13 +1721,13 @@ ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const std::complex<float>* x, std::int64_t incx,
-                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 ONEMATH_EXPORT sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                                  const std::complex<double>* x, std::int64_t incx,
-                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event hpmv(oneapi::math::device libkey, sycl::queue& queue, uplo upper_lower,

--- a/include/oneapi/math/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/cublas/blas_ct.hxx
@@ -1348,28 +1348,26 @@ void spr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
     oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
     oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
-           oneapi::math::index_base base) {
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
     oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
-           oneapi::math::index_base base) {
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
     oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
@@ -3776,16 +3774,16 @@ sycl::event spr2(backend_selector<backend::cublas> selector, uplo upper_lower, s
 }
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result, std::int64_t* result,
-                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result, std::int64_t* result,
-                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          base, dependencies);
     return done;
@@ -3793,8 +3791,7 @@ sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, co
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  std::int64_t* result, oneapi::math::index_base base,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          base, dependencies);
     return done;
@@ -3802,8 +3799,7 @@ sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  std::int64_t* result, oneapi::math::index_base base,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
                                                          base, dependencies);
     return done;

--- a/include/oneapi/math/blas/detail/cublas/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/cublas/blas_ct.hxx
@@ -620,25 +620,27 @@ void hpr(backend_selector<backend::cublas> selector, uplo upper_lower, std::int6
 }
 
 void iamin(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::cublas> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::cublas> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::cublas> selector, uplo upper_lower, std::int64_t n,
@@ -1346,25 +1348,29 @@ void spr2(backend_selector<backend::cublas> selector, uplo upper_lower, std::int
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::cublas> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, std::int64_t* result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::cublas> selector, std::int64_t n, sycl::buffer<float, 1>& x,
@@ -2557,34 +2563,34 @@ sycl::event hpr(backend_selector<backend::cublas> selector, uplo upper_lower, st
 }
 
 sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::cublas> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
@@ -3770,34 +3776,36 @@ sycl::event spr2(backend_selector<backend::cublas> selector, uplo upper_lower, s
 }
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  std::int64_t incx, std::int64_t* result, std::int64_t* result,
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  std::int64_t incx, std::int64_t* result, std::int64_t* result,
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
+                  std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::cublas> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
+                  std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::cublas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/cublas/onemath_blas_cublas.hxx
+++ b/include/oneapi/math/blas/detail/cublas/onemath_blas_cublas.hxx
@@ -131,28 +131,36 @@ void dotu(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>,
           sycl::buffer<std::complex<double>, 1>& result);
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result);
+           sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result);
+           sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result);
+           sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result);
+           sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void nrm2(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
           std::int64_t incx, sycl::buffer<float, 1>& result);
@@ -1145,31 +1153,43 @@ sycl::event dotu(sycl::queue& queue, std::int64_t n, const std::complex<double>*
                  std::complex<double>* result, const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event nrm2(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,

--- a/include/oneapi/math/blas/detail/generic/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/generic/blas_ct.hxx
@@ -626,25 +626,27 @@ void hpr(backend_selector<backend::generic> selector, uplo upper_lower, std::int
 }
 
 void iamin(backend_selector<backend::generic> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::generic> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::generic> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::generic> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::generic> selector, uplo upper_lower, std::int64_t n,
@@ -1352,25 +1354,27 @@ void spr2(backend_selector<backend::generic> selector, uplo upper_lower, std::in
 }
 
 void iamax(backend_selector<backend::generic> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::generic> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::generic> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::generic> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::generic> selector, std::int64_t n, sycl::buffer<float, 1>& x,
@@ -2564,34 +2568,34 @@ sycl::event hpr(backend_selector<backend::generic> selector, uplo upper_lower, s
 }
 
 sycl::event iamin(backend_selector<backend::generic> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::generic> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::generic> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::generic> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
@@ -3778,34 +3782,34 @@ sycl::event spr2(backend_selector<backend::generic> selector, uplo upper_lower, 
 }
 
 sycl::event iamax(backend_selector<backend::generic> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::generic> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::generic> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::generic> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::generic::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/mklcpu/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/mklcpu/blas_ct.hxx
@@ -622,25 +622,27 @@ void hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int6
 }
 
 void iamin(backend_selector<backend::mklcpu> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::mklcpu> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::mklcpu> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::mklcpu> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int64_t n,
@@ -1348,25 +1350,27 @@ void spr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, std::int
 }
 
 void iamax(backend_selector<backend::mklcpu> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::mklcpu> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::mklcpu> selector, std::int64_t n, sycl::buffer<float, 1>& x,
@@ -2559,34 +2563,34 @@ sycl::event hpr(backend_selector<backend::mklcpu> selector, uplo upper_lower, st
 }
 
 sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::mklcpu> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
@@ -3772,34 +3776,34 @@ sycl::event spr2(backend_selector<backend::mklcpu> selector, uplo upper_lower, s
 }
 
 sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::mklcpu> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklcpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/mklgpu/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/mklgpu/blas_ct.hxx
@@ -622,25 +622,27 @@ void hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int6
 }
 
 void iamin(backend_selector<backend::mklgpu> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::mklgpu> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::mklgpu> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::mklgpu> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int64_t n,
@@ -1348,25 +1350,27 @@ void spr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, std::int
 }
 
 void iamax(backend_selector<backend::mklgpu> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::mklgpu> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::mklgpu> selector, std::int64_t n, sycl::buffer<float, 1>& x,
@@ -2559,34 +2563,34 @@ sycl::event hpr(backend_selector<backend::mklgpu> selector, uplo upper_lower, st
 }
 
 sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::mklgpu> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
@@ -3772,34 +3776,34 @@ sycl::event spr2(backend_selector<backend::mklgpu> selector, uplo upper_lower, s
 }
 
 sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::mklgpu> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::mklgpu::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/netlib/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/netlib/blas_ct.hxx
@@ -622,25 +622,27 @@ void hpr(backend_selector<backend::netlib> selector, uplo upper_lower, std::int6
 }
 
 void iamin(backend_selector<backend::netlib> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::netlib> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::netlib> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::netlib> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::netlib> selector, uplo upper_lower, std::int64_t n,
@@ -1348,25 +1350,27 @@ void spr2(backend_selector<backend::netlib> selector, uplo upper_lower, std::int
 }
 
 void iamax(backend_selector<backend::netlib> selector, std::int64_t n, sycl::buffer<float, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::netlib> selector, std::int64_t n, sycl::buffer<double, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::netlib> selector, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::netlib> selector, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::netlib> selector, std::int64_t n, sycl::buffer<float, 1>& x,
@@ -2559,34 +2563,34 @@ sycl::event hpr(backend_selector<backend::netlib> selector, uplo upper_lower, st
 }
 
 sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::netlib> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
@@ -3772,34 +3776,34 @@ sycl::event spr2(backend_selector<backend::netlib> selector, uplo upper_lower, s
 }
 
 sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::netlib> selector, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::netlib::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                         dependencies);
+                                                         base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/onemath_blas_backends.hxx
+++ b/include/oneapi/math/blas/detail/onemath_blas_backends.hxx
@@ -678,32 +678,40 @@ ONEMATH_EXPORT void dotu(sycl::queue& queue, std::int64_t n,
                          sycl::buffer<std::complex<double>, 1>& result);
 
 ONEMATH_EXPORT void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamax(sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamax(sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                          std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamin(sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void iamin(sycl::queue& queue, std::int64_t n,
                           sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                          sycl::buffer<std::int64_t, 1>& result);
+                          sycl::buffer<std::int64_t, 1>& result,
+                          oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 ONEMATH_EXPORT void asum(sycl::queue& queue, std::int64_t n,
                          sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
@@ -2170,34 +2178,42 @@ ONEMATH_EXPORT sycl::event dotu(sycl::queue& queue, std::int64_t n, const std::c
 
 ONEMATH_EXPORT sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                                  std::int64_t incx, std::int64_t* result,
+                                 oneapi::math::index_base base = oneapi::math::index_base::zero,
                                  const std::vector<sycl::event>& dependencies = {});
 
 ONEMATH_EXPORT sycl::event asum(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,

--- a/include/oneapi/math/blas/detail/rocblas/blas_ct.hxx
+++ b/include/oneapi/math/blas/detail/rocblas/blas_ct.hxx
@@ -607,25 +607,25 @@ void hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t 
 }
 
 void iamin(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1>& x,
-           int64_t incx, sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           int64_t incx, sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1>& x,
-           int64_t incx, sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           int64_t incx, sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::rocblas> selector, int64_t n,
-           sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::complex<float>, 1>& x, int64_t incx, sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamin(backend_selector<backend::rocblas> selector, int64_t n,
-           sycl::buffer<std::complex<double>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::complex<double>, 1>& x, int64_t incx, sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result, base);
 }
 
 void hpmv(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t n,
@@ -1314,25 +1314,25 @@ void spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, int64_t
 }
 
 void iamax(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1>& x,
-           int64_t incx, sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           int64_t incx, sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<double, 1>& x,
-           int64_t incx, sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           int64_t incx, sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::rocblas> selector, int64_t n,
-           sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::complex<float>, 1>& x, int64_t incx, sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void iamax(backend_selector<backend::rocblas> selector, int64_t n,
-           sycl::buffer<std::complex<double>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
-    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result);
+           sycl::buffer<std::complex<double>, 1>& x, int64_t incx, sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result, base);
 }
 
 void rotm(backend_selector<backend::rocblas> selector, int64_t n, sycl::buffer<float, 1>& x,
@@ -2486,32 +2486,34 @@ sycl::event hpr(backend_selector<backend::rocblas> selector, uplo upper_lower, i
 }
 
 sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, const float* x,
-                  int64_t incx, int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  int64_t incx, int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n, const double* x,
-                  int64_t incx, int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  int64_t incx, int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
                   const std::complex<float>* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamin(backend_selector<backend::rocblas> selector, int64_t n,
                   const std::complex<double>* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamin(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
@@ -3667,32 +3669,34 @@ sycl::event spr2(backend_selector<backend::rocblas> selector, uplo upper_lower, 
 }
 
 sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, const float* x,
-                  int64_t incx, int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  int64_t incx, int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n, const double* x,
-                  int64_t incx, int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  int64_t incx, int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
                   const std::complex<float>* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 
 sycl::event iamax(backend_selector<backend::rocblas> selector, int64_t n,
                   const std::complex<double>* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = oneapi::math::blas::rocblas::MAJOR::iamax(selector.get_queue(), n, x, incx, result,
-                                                          dependencies);
+                                                          base, dependencies);
     return done;
 }
 

--- a/include/oneapi/math/blas/detail/rocblas/onemath_blas_rocblas.hxx
+++ b/include/oneapi/math/blas/detail/rocblas/onemath_blas_rocblas.hxx
@@ -133,28 +133,36 @@ void dotu(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>& 
           sycl::buffer<std::complex<double>, 1>& result);
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result);
+           sycl::buffer<int64_t, 1>& result,
+           oneapi::math::index_base base = oneapi::math::index_base::zero);
 
 void nrm2(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
           sycl::buffer<float, 1>& result);
@@ -1097,28 +1105,36 @@ sycl::event dotu(sycl::queue& queue, int64_t n, const std::complex<double>* x, i
                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const float* x, int64_t incx, int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const double* x, int64_t incx, int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  int64_t* result, oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<double>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  int64_t* result, oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const float* x, int64_t incx, int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const double* x, int64_t incx, int64_t* result,
+                  oneapi::math::index_base base = oneapi::math::index_base::zero,
                   const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  int64_t* result, oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<double>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies = {});
+                  int64_t* result, oneapi::math::index_base base = oneapi::math::index_base::zero,
+                  const std::vector<sycl::event>& dependencies = {});
 
 sycl::event nrm2(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
                  float* result, const std::vector<sycl::event>& dependencies = {});

--- a/src/blas/backends/armpl/armpl_level1.cxx
+++ b/src/blas/backends/armpl/armpl_level1.cxx
@@ -172,21 +172,24 @@ DOTU_LAUNCHER(std::complex<double>, ::cblas_zdotu_sub)
 
 template <typename T, typename CBLAS_FUNC>
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result, CBLAS_FUNC cblas_func) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base, CBLAS_FUNC cblas_func) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.template get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class armpl_kernel_iamin>(cgh, [=]() {
             accessor_result[0] =
-                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx);
+                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 #define IAMIN_LAUNCHER(TYPE, ROUTINE)                                                 \
     void iamin(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                    \
-        iamin(queue, n, x, incx, result, ROUTINE);                                    \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {     \
+        iamin(queue, n, x, incx, result, base, ROUTINE);                              \
     }
 
 IAMIN_LAUNCHER(float, ::cblas_isamin)
@@ -196,21 +199,24 @@ IAMIN_LAUNCHER(std::complex<double>, ::cblas_izamin)
 
 template <typename T, typename CBLAS_FUNC>
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result, CBLAS_FUNC cblas_func) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base, CBLAS_FUNC cblas_func) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.template get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class armpl_kernel_iamax>(cgh, [=]() {
             accessor_result[0] =
-                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx);
+                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 #define IAMAX_LAUNCHER(TYPE, ROUTINE)                                                 \
     void iamax(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                    \
-        iamax(queue, n, x, incx, result, ROUTINE);                                    \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {     \
+        iamax(queue, n, x, incx, result, base, ROUTINE);                              \
     }
 
 IAMAX_LAUNCHER(float, ::cblas_isamax)
@@ -561,22 +567,28 @@ DOTU_USM_LAUNCHER(std::complex<double>, ::cblas_zdotu_sub)
 
 template <typename T, typename CBLAS_FUNC>
 sycl::event iamin(sycl::queue& queue, int64_t n, const T* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies, CBLAS_FUNC cblas_func) {
+                  const std::vector<sycl::event>& dependencies, oneapi::math::index_base base,
+                  CBLAS_FUNC cblas_func) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; ++i) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class armpl_kernel_iamin>(
-            cgh, [=]() { result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx); });
+        host_task<class armpl_kernel_iamin>(cgh, [=]() {
+            result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx) + base ==
+                                oneapi::math::index_base::zero
+                            ? 0
+                            : 1;
+        });
     });
     return done;
 }
 
 #define IAMIN_USM_LAUNCHER(TYPE, ROUTINE)                                                          \
     sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, int64_t incx, int64_t* result, \
+                      oneapi::math::index_base base,                                               \
                       const std::vector<sycl::event>& dependencies) {                              \
-        return iamin(queue, n, x, incx, result, dependencies, ROUTINE);                            \
+        return iamin(queue, n, x, incx, result, base, dependencies, ROUTINE);                      \
     }
 
 IAMIN_USM_LAUNCHER(float, ::cblas_isamin)
@@ -586,22 +598,28 @@ IAMIN_USM_LAUNCHER(std::complex<double>, ::cblas_izamin)
 
 template <typename T, typename CBLAS_FUNC>
 sycl::event iamax(sycl::queue& queue, int64_t n, const T* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies, CBLAS_FUNC cblas_func) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies,
+                  CBLAS_FUNC cblas_func) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; ++i) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class armpl_kernel_iamax>(
-            cgh, [=]() { result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx); });
+        host_task<class armpl_kernel_iamax>(cgh, [=]() {
+            result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx) + base ==
+                                oneapi::math::index_base::zero
+                            ? 0
+                            : 1;
+        });
     });
     return done;
 }
 
 #define IAMAX_USM_LAUNCHER(TYPE, ROUTINE)                                                          \
     sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, int64_t incx, int64_t* result, \
+                      oneapi::math::index_base base,                                               \
                       const std::vector<sycl::event>& dependencies) {                              \
-        return iamax(queue, n, x, incx, result, dependencies, ROUTINE);                            \
+        return iamax(queue, n, x, incx, result, base, dependencies, ROUTINE);                      \
     }
 
 IAMAX_USM_LAUNCHER(float, ::cblas_isamax)

--- a/src/blas/backends/armpl/armpl_level1.cxx
+++ b/src/blas/backends/armpl/armpl_level1.cxx
@@ -178,10 +178,9 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x, int64_t incx,
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class armpl_kernel_iamin>(cgh, [=]() {
             accessor_result[0] =
-                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -205,10 +204,9 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x, int64_t incx,
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class armpl_kernel_iamax>(cgh, [=]() {
             accessor_result[0] =
-                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+                cblas_func((armpl_int_t)n, accessor_x.GET_MULTI_PTR, (armpl_int_t)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -575,10 +573,9 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const T* x, int64_t incx, int64
             cgh.depends_on(dependencies[i]);
         }
         host_task<class armpl_kernel_iamin>(cgh, [=]() {
-            result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx) + base ==
-                                oneapi::math::index_base::zero
-                            ? 0
-                            : 1;
+            result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -606,10 +603,9 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const T* x, int64_t incx, int64
             cgh.depends_on(dependencies[i]);
         }
         host_task<class armpl_kernel_iamax>(cgh, [=]() {
-            result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx) + base ==
-                                oneapi::math::index_base::zero
-                            ? 0
-                            : 1;
+            result[0] = cblas_func((armpl_int_t)n, x, (armpl_int_t)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -479,7 +479,7 @@ inline void iamax(const char* func_name, Func func, sycl::queue& queue, int64_t 
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
         cgh.single_task([=]() {
             result_acc[0] = std::max(
-                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)(int_res_acc[0] + (base == oneapi::math::index_base::zero ? -1 : 0)),
                 (int64_t)0);
         });
     });
@@ -569,7 +569,7 @@ inline void iamin(const char* func_name, Func func, sycl::queue& queue, int64_t 
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
         cgh.single_task([=]() {
             result_acc[0] = std::max(
-                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)(int_res_acc[0] + (base == oneapi::math::index_base::zero ? -1 : 0)),
                 (int64_t)0);
         });
     });
@@ -1138,7 +1138,7 @@ inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, i
         auto last_ev = queue.submit([&](sycl::handler& cgh) {
             cgh.single_task([=]() {
                 *result = std::max(
-                    (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+                    (int64_t)(*int_res_p + (base == oneapi::math::index_base::zero ? -1 : 0)),
                     (int64_t)0);
             });
         });
@@ -1147,8 +1147,9 @@ inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, i
         return last_ev;
     }
     else {
-        result[0] = std::max(
-            (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0), int64_t{ 0 });
+        result[0] =
+            std::max((int64_t)(*int_res_p + (base == oneapi::math::index_base::zero ? -1 : 0)),
+                     int64_t{ 0 });
         return done;
     }
 }
@@ -1245,7 +1246,7 @@ inline sycl::event iamin(const char* func_name, Func func, sycl::queue& queue, i
         auto last_ev = queue.submit([&](sycl::handler& cgh) {
             cgh.single_task([=]() {
                 *result = std::max(
-                    (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+                    (int64_t)(*int_res_p + (base == oneapi::math::index_base::zero ? -1 : 0)),
                     (int64_t)0);
             });
         });
@@ -1254,8 +1255,9 @@ inline sycl::event iamin(const char* func_name, Func func, sycl::queue& queue, i
         return last_ev;
     }
     else {
-        result[0] = std::max(
-            (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0), int64_t{ 0 });
+        result[0] =
+            std::max((int64_t)(*int_res_p + (base == oneapi::math::index_base::zero ? -1 : 0)),
+                     int64_t{ 0 });
         return done;
     }
 }

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -439,7 +439,8 @@ ROTMG_LAUNCHER(double, cublasDrotmg)
 
 template <typename Func, typename T>
 inline void iamax(const char* func_name, Func func, sycl::queue& queue, int64_t n,
-                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result) {
+                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     // cuBLAS does not support int64_t as return type for the data. So we need to
@@ -1095,6 +1096,7 @@ ROTMG_LAUNCHER_USM(double, cublasDrotmg)
 template <typename Func, typename T>
 inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, int64_t n,
                          const T* x, const int64_t incx, int64_t* result,
+                         oneapi::math::index_base base,
                          const std::vector<sycl::event>& dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -488,8 +488,8 @@ inline void iamax(const char* func_name, Func func, sycl::queue& queue, int64_t 
 
 #define IAMAX_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                                \
     void iamax(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result);                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base);            \
     }
 IAMAX_LAUNCHER(float, cublasIsamax)
 IAMAX_LAUNCHER(double, cublasIdamax)
@@ -1156,10 +1156,12 @@ inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, i
     }
 }
 
-#define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
-    sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx,         \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {          \
-        return iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies); \
+#define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                        \
+    sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base,  \
+                     dependencies);                                                     \
     }
 IAMAX_LAUNCHER_USM(float, cublasIsamax)
 IAMAX_LAUNCHER_USM(double, cublasIdamax)

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -1524,14 +1524,15 @@ ROTMG_LAUNCHER(double, cublasDrotmg)
 
 template <typename Func, typename T>
 inline void iamax(const char* func_name, Func func, sycl::queue& queue, int64_t n,
-                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result) {
+                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
     throw unimplemented("blas", "iamax", "for row_major layout");
 }
 
 #define IAMAX_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                                \
     void iamax(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result);                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base);            \
     }
 IAMAX_LAUNCHER(float, cublasIsamax)
 IAMAX_LAUNCHER(double, cublasIdamax)
@@ -1803,14 +1804,17 @@ ROTMG_LAUNCHER_USM(double, cublasDrotmg)
 template <typename Func, typename T>
 inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, int64_t n,
                          const T* x, const int64_t incx, int64_t* result,
+                         oneapi::math::index_base base,
                          const std::vector<sycl::event>& dependencies) {
     throw unimplemented("blas", "iamax", "for row_major layout");
 }
 
-#define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
-    sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx,         \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {          \
-        return iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies); \
+#define IAMAX_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                        \
+    sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamax(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base,  \
+                     dependencies);                                                     \
     }
 IAMAX_LAUNCHER_USM(float, cublasIsamax)
 IAMAX_LAUNCHER_USM(double, cublasIdamax)

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -477,8 +477,11 @@ inline void iamax(const char* func_name, Func func, sycl::queue& queue, int64_t 
     queue.submit([&](sycl::handler& cgh) {
         auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::read>(cgh);
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        cgh.single_task(
-            [=]() { result_acc[0] = std::max((int64_t)int_res_acc[0] - 1, (int64_t)0); });
+        cgh.single_task([=]() {
+            result_acc[0] = std::max(
+                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)0);
+        });
     });
 }
 
@@ -525,7 +528,8 @@ SWAP_LAUNCHER(std::complex<double>, cublasZswap)
 
 template <typename Func, typename T>
 inline void iamin(const char* func_name, Func func, sycl::queue& queue, int64_t n,
-                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result) {
+                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
     // cuBLAS does not support int64_t as return type for the data. So we need to
@@ -563,15 +567,18 @@ inline void iamin(const char* func_name, Func func, sycl::queue& queue, int64_t 
     queue.submit([&](sycl::handler& cgh) {
         auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::read>(cgh);
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        cgh.single_task(
-            [=]() { result_acc[0] = std::max((int64_t)int_res_acc[0] - 1, (int64_t)0); });
+        cgh.single_task([=]() {
+            result_acc[0] = std::max(
+                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)0);
+        });
     });
 }
 
 #define IAMIN_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                                \
     void iamin(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result);                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base);            \
     }
 IAMIN_LAUNCHER(float, cublasIsamin)
 IAMIN_LAUNCHER(double, cublasIdamin)
@@ -1129,14 +1136,19 @@ inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, i
     done.wait();
     if (result_on_device) {
         auto last_ev = queue.submit([&](sycl::handler& cgh) {
-            cgh.single_task([=]() { *result = std::max((int64_t)*int_res_p - 1, (int64_t)0); });
+            cgh.single_task([=]() {
+                *result = std::max(
+                    (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+                    (int64_t)0);
+            });
         });
         last_ev.wait();
         sycl::free(int_res_p, queue);
         return last_ev;
     }
     else {
-        result[0] = std::max((int64_t)(*int_res_p - 1), int64_t{ 0 });
+        result[0] = std::max(
+            (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0), int64_t{ 0 });
         return done;
     }
 }
@@ -1189,6 +1201,7 @@ SWAP_LAUNCHER_USM(std::complex<double>, cublasZswap)
 template <typename Func, typename T>
 inline sycl::event iamin(const char* func_name, Func func, sycl::queue& queue, int64_t n,
                          const T* x, const int64_t incx, int64_t* result,
+                         oneapi::math::index_base base,
                          const std::vector<sycl::event>& dependencies) {
     using cuDataType = typename CudaEquivalentType<T>::Type;
     overflow_check(n, incx);
@@ -1230,22 +1243,29 @@ inline sycl::event iamin(const char* func_name, Func func, sycl::queue& queue, i
     done.wait();
     if (result_on_device) {
         auto last_ev = queue.submit([&](sycl::handler& cgh) {
-            cgh.single_task([=]() { *result = std::max((int64_t)*int_res_p - 1, (int64_t)0); });
+            cgh.single_task([=]() {
+                *result = std::max(
+                    (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+                    (int64_t)0);
+            });
         });
         last_ev.wait();
         sycl::free(int_res_p, queue);
         return last_ev;
     }
     else {
-        result[0] = std::max((int64_t)(*int_res_p - 1), int64_t{ 0 });
+        result[0] = std::max(
+            (int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0), int64_t{ 0 });
         return done;
     }
 }
 
-#define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
-    sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx,         \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {          \
-        return iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies); \
+#define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                        \
+    sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base,  \
+                     dependencies);                                                     \
     }
 IAMIN_LAUNCHER_USM(float, cublasIsamin)
 IAMIN_LAUNCHER_USM(double, cublasIdamin)
@@ -1533,14 +1553,15 @@ SWAP_LAUNCHER(std::complex<double>, cublasZswap)
 
 template <typename Func, typename T>
 inline void iamin(const char* func_name, Func func, sycl::queue& queue, int64_t n,
-                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result) {
+                  sycl::buffer<T, 1>& x, const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
     throw unimplemented("blas", "iamin", "for row_major layout");
 }
 
 #define IAMIN_LAUNCHER(TYPE, CUBLAS_ROUTINE)                                                \
     void iamin(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result);                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base);            \
     }
 IAMIN_LAUNCHER(float, cublasIsamin)
 IAMIN_LAUNCHER(double, cublasIdamin)
@@ -1813,14 +1834,17 @@ SWAP_LAUNCHER_USM(std::complex<double>, cublasZswap)
 template <typename Func, typename T>
 inline sycl::event iamin(const char* func_name, Func func, sycl::queue& queue, int64_t n,
                          const T* x, const int64_t incx, int64_t* result,
+                         oneapi::math::index_base base,
                          const std::vector<sycl::event>& dependencies) {
     throw unimplemented("blas", "iamin", "for row_major layout");
 }
 
-#define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                                \
-    sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx,         \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {          \
-        return iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, dependencies); \
+#define IAMIN_LAUNCHER_USM(TYPE, CUBLAS_ROUTINE)                                        \
+    sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamin(#CUBLAS_ROUTINE, CUBLAS_ROUTINE, queue, n, x, incx, result, base,  \
+                     dependencies);                                                     \
     }
 IAMIN_LAUNCHER_USM(float, cublasIsamin)
 IAMIN_LAUNCHER_USM(double, cublasIdamin)

--- a/src/blas/backends/generic/generic_level1.cxx
+++ b/src/blas/backends/generic/generic_level1.cxx
@@ -33,7 +33,14 @@ void dotu(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>,
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<real_t, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    CALL_GENERIC_BLAS_FN(::blas::_iamax, queue, n, x, incx, result, base);
+    CALL_GENERIC_BLAS_FN(::blas::_iamax, queue, n, x, incx, result);
+    queue.submit([&](sycl::handler& cgh) {
+        auto result_acc = result.template get_access<sycl::access::mode::read_write>(cgh);
+        cgh.single_task([=]() {
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result_acc[0]++;
+        });
+    });
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1>& x,
@@ -44,7 +51,14 @@ void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<real_t, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    CALL_GENERIC_BLAS_FN(::blas::_iamin, queue, n, x, incx, result, base);
+    CALL_GENERIC_BLAS_FN(::blas::_iamin, queue, n, x, incx, result);
+    queue.submit([&](sycl::handler& cgh) {
+        auto result_acc = result.template get_access<sycl::access::mode::read_write>(cgh);
+        cgh.single_task([=]() {
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result_acc[0]++;
+        });
+    });
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1>& x,
@@ -221,7 +235,16 @@ sycl::event dotu(sycl::queue& queue, std::int64_t n, const std::complex<real_t>*
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const real_t* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    CALL_GENERIC_BLAS_USM_FN(::blas::_iamax, queue, n, x, incx, result, base, dependencies);
+    sycl::event e = [&]() -> sycl::event {
+        CALL_GENERIC_BLAS_USM_FN(::blas::_iamax, queue, n, x, incx, result, dependencies);
+    }();
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(e);
+        cgh.single_task([=]() {
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
+        });
+    });
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<real_t>* x,
@@ -233,7 +256,16 @@ sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<real_t>
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const real_t* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    CALL_GENERIC_BLAS_USM_FN(::blas::_iamin, queue, n, x, incx, result, base, dependencies);
+    sycl::event e = [&]() -> sycl::event {
+        CALL_GENERIC_BLAS_USM_FN(::blas::_iamin, queue, n, x, incx, result, dependencies);
+    }();
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(e);
+        cgh.single_task([=]() {
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
+        });
+    });
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<real_t>* x,

--- a/src/blas/backends/generic/generic_level1.cxx
+++ b/src/blas/backends/generic/generic_level1.cxx
@@ -32,22 +32,24 @@ void dotu(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>,
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<real_t, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    CALL_GENERIC_BLAS_FN(::blas::_iamax, queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    CALL_GENERIC_BLAS_FN(::blas::_iamax, queue, n, x, incx, result, base);
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
     throw unimplemented("blas", "iamax", "");
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<real_t, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    CALL_GENERIC_BLAS_FN(::blas::_iamin, queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    CALL_GENERIC_BLAS_FN(::blas::_iamin, queue, n, x, incx, result, base);
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
     throw unimplemented("blas", "iamin", "");
 }
 
@@ -217,23 +219,25 @@ sycl::event dotu(sycl::queue& queue, std::int64_t n, const std::complex<real_t>*
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const real_t* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies) {
-    CALL_GENERIC_BLAS_USM_FN(::blas::_iamax, queue, n, x, incx, result, dependencies);
+                  std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
+    CALL_GENERIC_BLAS_USM_FN(::blas::_iamax, queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<real_t>* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     throw unimplemented("blas", "iamax", " for USM");
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const real_t* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies) {
-    CALL_GENERIC_BLAS_USM_FN(::blas::_iamin, queue, n, x, incx, result, dependencies);
+                  std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
+    CALL_GENERIC_BLAS_USM_FN(::blas::_iamin, queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<real_t>* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     throw unimplemented("blas", "iamin", " for USM");
 }

--- a/src/blas/backends/generic/generic_level1.cxx
+++ b/src/blas/backends/generic/generic_level1.cxx
@@ -34,13 +34,13 @@ void dotu(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>,
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<real_t, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
     CALL_GENERIC_BLAS_FN(::blas::_iamax, queue, n, x, incx, result);
-    queue.submit([&](sycl::handler& cgh) {
-        auto result_acc = result.template get_access<sycl::access::mode::read_write>(cgh);
-        cgh.single_task([=]() {
-            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
-                result_acc[0]++;
+    // TODO: It is better to do this in the _iamax kernel in https://github.com/uxlfoundation/generic-sycl-components
+    if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1) {
+        queue.submit([&](sycl::handler& cgh) {
+            auto result_acc = result.template get_access<sycl::access::mode::read_write>(cgh);
+            cgh.single_task([=]() { result_acc[0]++; });
         });
-    });
+    }
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1>& x,
@@ -52,13 +52,13 @@ void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<real_t, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
     CALL_GENERIC_BLAS_FN(::blas::_iamin, queue, n, x, incx, result);
-    queue.submit([&](sycl::handler& cgh) {
-        auto result_acc = result.template get_access<sycl::access::mode::read_write>(cgh);
-        cgh.single_task([=]() {
-            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
-                result_acc[0]++;
+    // TODO: It is better to do this in the _iamin kernel in https://github.com/uxlfoundation/generic-sycl-components
+    if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1) {
+        queue.submit([&](sycl::handler& cgh) {
+            auto result_acc = result.template get_access<sycl::access::mode::read_write>(cgh);
+            cgh.single_task([=]() { result_acc[0]++; });
         });
-    });
+    }
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<real_t>, 1>& x,
@@ -238,13 +238,14 @@ sycl::event iamax(sycl::queue& queue, std::int64_t n, const real_t* x, std::int6
     sycl::event e = [&]() -> sycl::event {
         CALL_GENERIC_BLAS_USM_FN(::blas::_iamax, queue, n, x, incx, result, dependencies);
     }();
-    return queue.submit([&](sycl::handler& cgh) {
-        cgh.depends_on(e);
-        cgh.single_task([=]() {
-            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
-                result[0]++;
+    // TODO: It is better to do this in the _iamax kernel in https://github.com/uxlfoundation/generic-sycl-components
+    if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1) {
+        return queue.submit([&](sycl::handler& cgh) {
+            cgh.depends_on(e);
+            cgh.single_task([=]() { result[0]++; });
         });
-    });
+    }
+    return e;
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<real_t>* x,
@@ -259,13 +260,14 @@ sycl::event iamin(sycl::queue& queue, std::int64_t n, const real_t* x, std::int6
     sycl::event e = [&]() -> sycl::event {
         CALL_GENERIC_BLAS_USM_FN(::blas::_iamin, queue, n, x, incx, result, dependencies);
     }();
-    return queue.submit([&](sycl::handler& cgh) {
-        cgh.depends_on(e);
-        cgh.single_task([=]() {
-            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
-                result[0]++;
+    // TODO: It is better to do this in the _iamin kernel in https://github.com/uxlfoundation/generic-sycl-components
+    if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1) {
+        return queue.submit([&](sycl::handler& cgh) {
+            cgh.depends_on(e);
+            cgh.single_task([=]() { result[0]++; });
         });
-    });
+    }
+    return e;
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<real_t>* x,

--- a/src/blas/backends/mkl_common/mkl_level1.cxx
+++ b/src/blas/backends/mkl_common/mkl_level1.cxx
@@ -283,43 +283,47 @@ void swap(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>,
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result));
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result));
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result));
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result));
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result));
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result));
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result));
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
-           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result));
+           std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
 }
 
 // USM APIs
@@ -619,45 +623,49 @@ sycl::event swap(sycl::queue& queue, std::int64_t n, std::complex<double>* x, st
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, dependencies));
+                  std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, dependencies));
+                  std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, dependencies));
+                  std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
-                  std::int64_t* result, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, dependencies));
+                  std::int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
 }

--- a/src/blas/backends/mkl_common/mkl_level1.cxx
+++ b/src/blas/backends/mkl_common/mkl_level1.cxx
@@ -284,46 +284,70 @@ void swap(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>,
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result, base));
+    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
+                                                base == oneapi::math::index_base::zero
+                                                    ? oneapi::mkl::index_base::zero
+                                                    : oneapi::mkl::index_base::one));
 }
 
 // USM APIs
@@ -625,47 +649,79 @@ sycl::event swap(sycl::queue& queue, std::int64_t n, std::complex<double>* x, st
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result, base, dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
+                                                    base == oneapi::math::index_base::zero
+                                                        ? oneapi::mkl::index_base::zero
+                                                        : oneapi::mkl::index_base::one,
+                                                    dependencies));
 }

--- a/src/blas/backends/mkl_common/mkl_level1.cxx
+++ b/src/blas/backends/mkl_common/mkl_level1.cxx
@@ -284,70 +284,54 @@ void swap(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>,
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamax(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(blas_major::iamin(queue, n, x, incx, result,
-                                                base == oneapi::math::index_base::zero
-                                                    ? oneapi::mkl::index_base::zero
-                                                    : oneapi::mkl::index_base::one));
+    RETHROW_ONEMKL_EXCEPTIONS(
+        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
 }
 
 // USM APIs
@@ -649,79 +633,55 @@ sycl::event swap(sycl::queue& queue, std::int64_t n, std::complex<double>* x, st
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
 
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(queue, n, x, incx, result,
-                                                    base == oneapi::math::index_base::zero
-                                                        ? oneapi::mkl::index_base::zero
-                                                        : oneapi::mkl::index_base::one,
-                                                    dependencies));
+    RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
+        queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -315,8 +315,9 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -327,8 +328,9 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t in
         auto accessor_x = x.template get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -339,8 +341,9 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& 
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -351,8 +354,9 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>&
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -363,8 +367,9 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -375,8 +380,9 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t in
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -387,8 +393,9 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& 
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -399,8 +406,9 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>&
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
-                                 (base == oneapi::math::index_base::zero ? 0 : 1);
+            accessor_result[0] = ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                accessor_result[0]++;
         });
     });
 }
@@ -1066,8 +1074,9 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const float* x, int64_t incx, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_isamin_usm>(cgh, [=]() {
-            result[0] = ::cblas_isamin((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_isamin((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1081,8 +1090,9 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const double* x, int64_t incx, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_idamin_usm>(cgh, [=]() {
-            result[0] = ::cblas_idamin((const int)n, x, (const int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_idamin((const int)n, x, (const int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1097,8 +1107,9 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<float>* x, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_icamin_usm>(cgh, [=]() {
-            result[0] = ::cblas_icamin((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_icamin((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1113,8 +1124,9 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<double>* x, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_izamin_usm>(cgh, [=]() {
-            result[0] = ::cblas_izamin((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_izamin((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1128,8 +1140,9 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const float* x, int64_t incx, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_isamax_usm>(cgh, [=]() {
-            result[0] = ::cblas_isamax((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_isamax((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1143,8 +1156,9 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const double* x, int64_t incx, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_idamax_usm>(cgh, [=]() {
-            result[0] = ::cblas_idamax((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_idamax((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1159,8 +1173,9 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_icamax_usm>(cgh, [=]() {
-            result[0] = ::cblas_icamax((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_icamax((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;
@@ -1175,8 +1190,9 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<double>* x, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_izamax_usm>(cgh, [=]() {
-            result[0] = ::cblas_izamax((int)n, x, (int)incx) +
-                        (base == oneapi::math::index_base::zero ? 0 : 1);
+            result[0] = ::cblas_izamax((int)n, x, (int)incx);
+            if (base == oneapi::math::index_base::one && n >= 1 && incx >= 1)
+                result[0]++;
         });
     });
     return done;

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -1090,9 +1090,8 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const float* x, int64_t incx, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_isamin_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_isamin((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_isamin((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;
@@ -1124,9 +1123,8 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<float>* x, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_icamin_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_icamin((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_icamin((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;
@@ -1141,9 +1139,8 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<double>* x, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_izamin_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_izamin((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_izamin((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;
@@ -1157,9 +1154,8 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const float* x, int64_t incx, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_isamax_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_isamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_isamax((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;
@@ -1173,9 +1169,8 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const double* x, int64_t incx, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_idamax_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_idamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_idamax((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;
@@ -1190,9 +1185,8 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, i
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_icamax_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_icamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_icamax((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;
@@ -1207,9 +1201,8 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<double>* x, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_izamax_usm>(cgh, [=]() {
-            result[0] =
-                ::cblas_izamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
-                                                                                              : 1;
+            result[0] = ::cblas_izamax((int)n, x, (int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -310,89 +310,121 @@ void dotu(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>& 
 }
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.template get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamin>(cgh, [=]() {
-            accessor_result[0] = ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
 
 void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>& x, int64_t incx,
-           sycl::buffer<int64_t, 1>& result) {
+           sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamax>(cgh, [=]() {
-            accessor_result[0] = ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx);
+            accessor_result[0] =
+                ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
+                        oneapi::math::index_base::zero
+                    ? 0
+                    : 1;
         });
     });
 }
@@ -1051,105 +1083,134 @@ sycl::event dotu(sycl::queue& queue, int64_t n, const std::complex<double>* x, i
 }
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const float* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_isamin_usm>(
-            cgh, [=]() { result[0] = ::cblas_isamin((int)n, x, (int)incx); });
+        host_task<class netlib_isamin_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_isamin((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
     });
     return done;
 }
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const double* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_idamin_usm>(
-            cgh, [=]() { result[0] = ::cblas_idamin((const int)n, x, (const int)incx); });
+        host_task<class netlib_idamin_usm>(cgh, [=]() {
+            result[0] = ::cblas_idamin((const int)n, x, (const int)incx) + base ==
+                                oneapi::math::index_base::zero
+                            ? 0
+                            : 1;
+        });
     });
     return done;
 }
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_icamin_usm>(
-            cgh, [=]() { result[0] = ::cblas_icamin((int)n, x, (int)incx); });
+        host_task<class netlib_icamin_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_icamin((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
     });
     return done;
 }
 
 sycl::event iamin(sycl::queue& queue, int64_t n, const std::complex<double>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  int64_t* result, oneapi::math::index_base base,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_izamin_usm>(
-            cgh, [=]() { result[0] = ::cblas_izamin((int)n, x, (int)incx); });
+        host_task<class netlib_izamin_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_izamin((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
     });
     return done;
 }
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const float* x, int64_t incx, int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_isamax_usm>(
-            cgh, [=]() { result[0] = ::cblas_isamax((int)n, x, (int)incx); });
+        host_task<class netlib_isamax_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_isamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
     });
     return done;
 }
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const double* x, int64_t incx, int64_t* result,
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+    auto done = queue.submit([&](sycl::handler& cgh) {
+        int64_t num_events = dependencies.size();
+        for (int64_t i = 0; i < num_events; i++) {
+            cgh.depends_on(dependencies[i]);
+        }
+        host_task<class netlib_idamax_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_idamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
+    });
+    return done;
+}
+
+sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
+                  oneapi::math::index_base base, int64_t* result,
                   const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_idamax_usm>(
-            cgh, [=]() { result[0] = ::cblas_idamax((int)n, x, (int)incx); });
-    });
-    return done;
-}
-
-sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies) {
-    auto done = queue.submit([&](sycl::handler& cgh) {
-        int64_t num_events = dependencies.size();
-        for (int64_t i = 0; i < num_events; i++) {
-            cgh.depends_on(dependencies[i]);
-        }
-        host_task<class netlib_icamax_usm>(
-            cgh, [=]() { result[0] = ::cblas_icamax((int)n, x, (int)incx); });
+        host_task<class netlib_icamax_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_icamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
     });
     return done;
 }
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<double>* x, int64_t incx,
-                  int64_t* result, const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, int64_t* result,
+                  const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        host_task<class netlib_izamax_usm>(
-            cgh, [=]() { result[0] = ::cblas_izamax((int)n, x, (int)incx); });
+        host_task<class netlib_izamax_usm>(cgh, [=]() {
+            result[0] =
+                ::cblas_izamax((int)n, x, (int)incx) + base == oneapi::math::index_base::zero ? 0
+                                                                                              : 1;
+        });
     });
     return done;
 }

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -1151,7 +1151,7 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const double* x, int64_t incx, 
 }
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, int64_t incx,
-                  oneapi::math::index_base base, int64_t* result,
+                  int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();
@@ -1167,7 +1167,7 @@ sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<float>* x, i
 }
 
 sycl::event iamax(sycl::queue& queue, int64_t n, const std::complex<double>* x, int64_t incx,
-                  oneapi::math::index_base base, int64_t* result,
+                  int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     auto done = queue.submit([&](sycl::handler& cgh) {
         int64_t num_events = dependencies.size();

--- a/src/blas/backends/netlib/netlib_level1.cxx
+++ b/src/blas/backends/netlib/netlib_level1.cxx
@@ -315,11 +315,8 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamin>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_isamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -330,11 +327,8 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t in
         auto accessor_x = x.template get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.template get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamin>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_idamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -345,11 +339,8 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& 
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamin>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_icamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -360,11 +351,8 @@ void iamin(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>&
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamin>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_izamin((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -375,11 +363,8 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<float, 1>& x, int64_t inc
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_isamax>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_isamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -390,11 +375,8 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<double, 1>& x, int64_t in
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_idamax>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_idamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -405,11 +387,8 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<float>, 1>& 
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_icamax>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_icamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -420,11 +399,8 @@ void iamax(sycl::queue& queue, int64_t n, sycl::buffer<std::complex<double>, 1>&
         auto accessor_x = x.get_access<sycl::access::mode::read>(cgh);
         auto accessor_result = result.get_access<sycl::access::mode::write>(cgh);
         host_task<class netlib_izamax>(cgh, [=]() {
-            accessor_result[0] =
-                ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) + base ==
-                        oneapi::math::index_base::zero
-                    ? 0
-                    : 1;
+            accessor_result[0] = ::cblas_izamax((int)n, accessor_x.GET_MULTI_PTR, (int)incx) +
+                                 (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
 }
@@ -1105,10 +1081,8 @@ sycl::event iamin(sycl::queue& queue, int64_t n, const double* x, int64_t incx, 
             cgh.depends_on(dependencies[i]);
         }
         host_task<class netlib_idamin_usm>(cgh, [=]() {
-            result[0] = ::cblas_idamin((const int)n, x, (const int)incx) + base ==
-                                oneapi::math::index_base::zero
-                            ? 0
-                            : 1;
+            result[0] = ::cblas_idamin((const int)n, x, (const int)incx) +
+                        (base == oneapi::math::index_base::zero ? 0 : 1);
         });
     });
     return done;

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -507,7 +507,7 @@ inline void iamax(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
         cgh.single_task([=]() {
             result_acc[0] = std::max(
-                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)(int_res_acc[0] + (base == oneapi::math::index_base::zero ? -1 : 0)),
                 (int64_t)0);
         });
     });
@@ -604,7 +604,7 @@ inline void iamin(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
         cgh.single_task([=]() {
             result_acc[0] = std::max(
-                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)(int_res_acc[0] + (base == oneapi::math::index_base::zero ? -1 : 0)),
                 (int64_t)0);
         });
     });
@@ -1076,7 +1076,7 @@ inline sycl::event iamax(Func func, sycl::queue& queue, int64_t n, const T* x, c
     });
 
     done.wait_and_throw();
-    result[0] = std::max((int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+    result[0] = std::max((int64_t)(*int_res_p + (base == oneapi::math::index_base::zero ? -1 : 0)),
                          int64_t{ 0 });
     return done;
 }
@@ -1161,7 +1161,7 @@ inline sycl::event iamin(Func func, sycl::queue& queue, int64_t n, const T* x, c
     });
 
     done.wait_and_throw();
-    result[0] = std::max((int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+    result[0] = std::max((int64_t)(*int_res_p + (base == oneapi::math::index_base::zero ? -1 : 0)),
                          int64_t{ 0 });
     return done;
 }

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -464,7 +464,8 @@ ROTMG_LAUNCHER(double, rocblas_drotmg)
 
 template <typename Func, typename T>
 inline void iamax(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x,
-                  const int64_t incx, sycl::buffer<int64_t, 1>& result) {
+                  const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
 
@@ -504,15 +505,18 @@ inline void iamax(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
     queue.submit([&](sycl::handler& cgh) {
         auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::read>(cgh);
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        cgh.single_task(
-            [=]() { result_acc[0] = std::max((int64_t)int_res_acc[0] - 1, (int64_t)0); });
+        cgh.single_task([=]() {
+            result_acc[0] = std::max(
+                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)0);
+        });
     });
 }
 
 #define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
     void iamax(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, base);                            \
     }
 
 IAMAX_LAUNCHER(float, rocblas_isamax)
@@ -557,7 +561,8 @@ SWAP_LAUNCHER(std::complex<double>, rocblas_zswap)
 
 template <typename Func, typename T>
 inline void iamin(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x,
-                  const int64_t incx, sycl::buffer<int64_t, 1>& result) {
+                  const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
 
@@ -597,15 +602,18 @@ inline void iamin(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
     queue.submit([&](sycl::handler& cgh) {
         auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::read>(cgh);
         auto result_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        cgh.single_task(
-            [=]() { result_acc[0] = std::max((int64_t)int_res_acc[0] - 1, (int64_t)0); });
+        cgh.single_task([=]() {
+            result_acc[0] = std::max(
+                (int64_t)(int_res_acc[0] + base == oneapi::math::index_base::zero ? -1 : 0),
+                (int64_t)0);
+        });
     });
 }
 
 #define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
     void iamin(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, base);                            \
     }
 
 IAMIN_LAUNCHER(float, rocblas_isamin)
@@ -1039,7 +1047,8 @@ ROTMG_LAUNCHER_USM(double, rocblas_drotmg)
 
 template <typename Func, typename T>
 inline sycl::event iamax(Func func, sycl::queue& queue, int64_t n, const T* x, const int64_t incx,
-                         int64_t* result, const std::vector<sycl::event>& dependencies) {
+                         int64_t* result, oneapi::math::index_base base,
+                         const std::vector<sycl::event>& dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
     // rocBLAS does not support int64_t as return type for the data by default. So we need to
@@ -1067,14 +1076,16 @@ inline sycl::event iamax(Func func, sycl::queue& queue, int64_t n, const T* x, c
     });
 
     done.wait_and_throw();
-    result[0] = std::max((int64_t)(*int_res_p - 1), int64_t{ 0 });
+    result[0] = std::max((int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+                         int64_t{ 0 });
     return done;
 }
 
 #define IAMAX_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
     sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {  \
-        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, base, dependencies);   \
     }
 
 IAMAX_LAUNCHER_USM(float, rocblas_isamax)
@@ -1120,7 +1131,8 @@ SWAP_LAUNCHER_USM(std::complex<double>, rocblas_zswap)
 
 template <typename Func, typename T>
 inline sycl::event iamin(Func func, sycl::queue& queue, int64_t n, const T* x, const int64_t incx,
-                         int64_t* result, const std::vector<sycl::event>& dependencies) {
+                         int64_t* result, oneapi::math::index_base base,
+                         const std::vector<sycl::event>& dependencies) {
     using rocDataType = typename RocEquivalentType<T>::Type;
     overflow_check(n, incx);
     // rocBLAS does not support int64_t as return type for the data by default. So we need to
@@ -1149,14 +1161,16 @@ inline sycl::event iamin(Func func, sycl::queue& queue, int64_t n, const T* x, c
     });
 
     done.wait_and_throw();
-    result[0] = std::max((int64_t)(*int_res_p - 1), int64_t{ 0 });
+    result[0] = std::max((int64_t)(*int_res_p + base == oneapi::math::index_base::zero ? -1 : 0),
+                         int64_t{ 0 });
     return done;
 }
 
 #define IAMIN_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
     sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {  \
-        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, base, dependencies);   \
     }
 
 IAMIN_LAUNCHER_USM(float, rocblas_isamin)
@@ -1413,14 +1427,15 @@ ROTMG_LAUNCHER(double, rocblas_drotmg)
 
 template <typename Func, typename T>
 inline void iamax(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x,
-                  const int64_t incx, sycl::buffer<int64_t, 1>& result) {
-    column_major::iamax(func, queue, n, x, incx, result);
+                  const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
+    column_major::iamax(func, queue, n, x, incx, result, base);
 }
 
 #define IAMAX_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
     void iamax(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
+        iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, base);                            \
     }
 
 IAMAX_LAUNCHER(float, rocblas_isamax)
@@ -1451,14 +1466,15 @@ SWAP_LAUNCHER(std::complex<double>, rocblas_zswap)
 
 template <typename Func, typename T>
 inline void iamin(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& x,
-                  const int64_t incx, sycl::buffer<int64_t, 1>& result) {
-    column_major::iamin(func, queue, n, x, incx, result);
+                  const int64_t incx, sycl::buffer<int64_t, 1>& result,
+                  oneapi::math::index_base base) {
+    column_major::iamin(func, queue, n, x, incx, result, base);
 }
 
 #define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
     void iamin(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               sycl::buffer<int64_t, 1>& result) {                                          \
-        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result);                                  \
+               oneapi::math::index_base base, sycl::buffer<int64_t, 1>& result) {           \
+        iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, base);                            \
     }
 
 IAMIN_LAUNCHER(float, rocblas_isamin)
@@ -1699,14 +1715,16 @@ ROTMG_LAUNCHER_USM(double, rocblas_drotmg)
 
 template <typename Func, typename T>
 inline sycl::event iamax(Func func, sycl::queue& queue, int64_t n, const T* x, const int64_t incx,
-                         int64_t* result, const std::vector<sycl::event>& dependencies) {
-    return column_major::iamax(func, queue, n, x, incx, result, dependencies);
+                         int64_t* result, oneapi::math::index_base base,
+                         const std::vector<sycl::event>& dependencies) {
+    return column_major::iamax(func, queue, n, x, incx, result, base, dependencies);
 }
 
 #define IAMAX_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
     sycl::event iamax(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {  \
-        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamax(ROCBLAS_ROUTINE, queue, n, x, incx, result, base, dependencies);   \
     }
 
 IAMAX_LAUNCHER_USM(float, rocblas_isamax)
@@ -1737,14 +1755,16 @@ SWAP_LAUNCHER_USM(std::complex<double>, rocblas_zswap)
 
 template <typename Func, typename T>
 inline sycl::event iamin(Func func, sycl::queue& queue, int64_t n, const T* x, const int64_t incx,
-                         int64_t* result, const std::vector<sycl::event>& dependencies) {
-    return column_major::iamin(func, queue, n, x, incx, result, dependencies);
+                         int64_t* result, oneapi::math::index_base base,
+                         const std::vector<sycl::event>& dependencies) {
+    return column_major::iamin(func, queue, n, x, incx, result, base, dependencies);
 }
 
 #define IAMIN_LAUNCHER_USM(TYPE, ROCBLAS_ROUTINE)                                       \
     sycl::event iamin(sycl::queue& queue, int64_t n, const TYPE* x, const int64_t incx, \
-                      int64_t* result, const std::vector<sycl::event>& dependencies) {  \
-        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, dependencies);         \
+                      int64_t* result, oneapi::math::index_base base,                   \
+                      const std::vector<sycl::event>& dependencies) {                   \
+        return iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, base, dependencies);   \
     }
 
 IAMIN_LAUNCHER_USM(float, rocblas_isamin)

--- a/src/blas/backends/rocblas/rocblas_level1.cpp
+++ b/src/blas/backends/rocblas/rocblas_level1.cpp
@@ -1473,7 +1473,7 @@ inline void iamin(Func func, sycl::queue& queue, int64_t n, sycl::buffer<T, 1>& 
 
 #define IAMIN_LAUNCHER(TYPE, ROCBLAS_ROUTINE)                                               \
     void iamin(sycl::queue& queue, int64_t n, sycl::buffer<TYPE, 1>& x, const int64_t incx, \
-               oneapi::math::index_base base, sycl::buffer<int64_t, 1>& result) {           \
+               sycl::buffer<int64_t, 1>& result, oneapi::math::index_base base) {           \
         iamin(ROCBLAS_ROUTINE, queue, n, x, incx, result, base);                            \
     }
 

--- a/src/blas/blas_loader.cpp
+++ b/src/blas/blas_loader.cpp
@@ -241,47 +241,51 @@ void dotu(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_isamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_isamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_idamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_idamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_icamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_icamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_izamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_izamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_isamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_isamax_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_idamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_idamax_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_icamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_icamax_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].column_major_izamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].column_major_izamax_sycl(queue, n, x, incx, result, base);
 }
 
 void nrm2(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
@@ -2042,59 +2046,59 @@ sycl::event dotu(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_isamin_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+    return function_tables[{ libkey, queue }].column_major_isamin_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_idamin_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+    return function_tables[{ libkey, queue }].column_major_idamin_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_icamin_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+    return function_tables[{ libkey, queue }].column_major_icamin_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_izamin_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+    return function_tables[{ libkey, queue }].column_major_izamin_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_isamax_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+    return function_tables[{ libkey, queue }].column_major_isamax_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_idamax_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+    return function_tables[{ libkey, queue }].column_major_idamax_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_icamax_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+    return function_tables[{ libkey, queue }].column_major_icamax_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
-    return function_tables[{ libkey, queue }].column_major_izamax_usm_sycl(queue, n, x, incx,
-                                                                           result, dependencies);
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
+    return function_tables[{ libkey, queue }].column_major_izamax_usm_sycl(
+        queue, n, x, incx, result, base, dependencies);
 }
 
 sycl::event nrm2(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
@@ -4219,47 +4223,51 @@ void dotu(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_isamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_isamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_idamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_idamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_icamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_icamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_izamin_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_izamin_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_isamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<float, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_isamax_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
-           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_idamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<double, 1>& x, std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+           oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_idamax_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_icamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_icamax_sycl(queue, n, x, incx, result, base);
 }
 
 void iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
            sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-           sycl::buffer<std::int64_t, 1>& result) {
-    function_tables[{ libkey, queue }].row_major_izamax_sycl(queue, n, x, incx, result);
+           sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    function_tables[{ libkey, queue }].row_major_izamax_sycl(queue, n, x, incx, result, base);
 }
 
 void nrm2(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
@@ -6020,59 +6028,59 @@ sycl::event dotu(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_isamin_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_idamin_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_icamin_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamin(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_izamin_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const float* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_isamax_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n, const double* x,
-                  std::int64_t incx, std::int64_t* result,
+                  std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_idamax_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<float>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_icamax_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event iamax(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,
                   const std::complex<double>* x, std::int64_t incx, std::int64_t* result,
-                  const std::vector<sycl::event>& dependencies) {
+                  oneapi::math::index_base base, const std::vector<sycl::event>& dependencies) {
     return function_tables[{ libkey, queue }].row_major_izamax_usm_sycl(queue, n, x, incx, result,
-                                                                        dependencies);
+                                                                        base, dependencies);
 }
 
 sycl::event nrm2(oneapi::math::device libkey, sycl::queue& queue, std::int64_t n,

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -154,15 +154,19 @@ typedef struct {
                                     sycl::buffer<std::complex<double>, 1>& y, std::int64_t incy,
                                     sycl::buffer<std::complex<double>, 1>& result);
     void (*column_major_isamin_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_idamin_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_icamin_sycl)(sycl::queue& queue, std::int64_t n,
                                      sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                                     sycl::buffer<std::int64_t, 1>& result);
+                                     sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_izamin_sycl)(sycl::queue& queue, std::int64_t n,
                                      sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                                     sycl::buffer<std::int64_t, 1>& result);
+                                     sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_isamax_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
                                      std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
                                      oneapi::math::index_base base);
@@ -1283,17 +1287,19 @@ typedef struct {
                                                const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_isamin_usm_sycl)(sycl::queue& queue, std::int64_t n, const float* x,
                                                 std::int64_t incx, std::int64_t* result,
+                                                oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_idamin_usm_sycl)(sycl::queue& queue, std::int64_t n, const double* x,
                                                 std::int64_t incx, std::int64_t* result,
+                                                oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_icamin_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                                 const std::complex<float>* x, std::int64_t incx,
-                                                std::int64_t* result,
+                                                std::int64_t* result, oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_izamin_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                                 const std::complex<double>* x, std::int64_t incx,
-                                                std::int64_t* result,
+                                                std::int64_t* result, oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_isamax_usm_sycl)(sycl::queue& queue, std::int64_t n, const float* x,
                                                 std::int64_t incx, std::int64_t* result,

--- a/src/blas/function_table.hpp
+++ b/src/blas/function_table.hpp
@@ -164,15 +164,19 @@ typedef struct {
                                      sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
                                      sycl::buffer<std::int64_t, 1>& result);
     void (*column_major_isamax_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_idamax_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                     std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_icamax_sycl)(sycl::queue& queue, std::int64_t n,
                                      sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                                     sycl::buffer<std::int64_t, 1>& result);
+                                     sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_izamax_sycl)(sycl::queue& queue, std::int64_t n,
                                      sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                                     sycl::buffer<std::int64_t, 1>& result);
+                                     sycl::buffer<std::int64_t, 1>& result,
+                                     oneapi::math::index_base base);
     void (*column_major_scnrm2_sycl)(sycl::queue& queue, std::int64_t n,
                                      sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
                                      sycl::buffer<float, 1>& result);
@@ -1293,17 +1297,19 @@ typedef struct {
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_isamax_usm_sycl)(sycl::queue& queue, std::int64_t n, const float* x,
                                                 std::int64_t incx, std::int64_t* result,
+                                                oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_idamax_usm_sycl)(sycl::queue& queue, std::int64_t n, const double* x,
                                                 std::int64_t incx, std::int64_t* result,
+                                                oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_icamax_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                                 const std::complex<float>* x, std::int64_t incx,
-                                                std::int64_t* result,
+                                                std::int64_t* result, oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_izamax_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                                 const std::complex<double>* x, std::int64_t incx,
-                                                std::int64_t* result,
+                                                std::int64_t* result, oneapi::math::index_base base,
                                                 const std::vector<sycl::event>& dependencies);
     sycl::event (*column_major_scnrm2_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                                 const std::complex<float>* x, std::int64_t incx,
@@ -2627,25 +2633,33 @@ typedef struct {
                                  sycl::buffer<std::complex<double>, 1>& y, std::int64_t incy,
                                  sycl::buffer<std::complex<double>, 1>& result);
     void (*row_major_isamin_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_idamin_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_icamin_sycl)(sycl::queue& queue, std::int64_t n,
                                   sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                                  sycl::buffer<std::int64_t, 1>& result);
+                                  sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_izamin_sycl)(sycl::queue& queue, std::int64_t n,
                                   sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                                  sycl::buffer<std::int64_t, 1>& result);
+                                  sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_isamax_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x,
-                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_idamax_sycl)(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x,
-                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result);
+                                  std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_icamax_sycl)(sycl::queue& queue, std::int64_t n,
                                   sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
-                                  sycl::buffer<std::int64_t, 1>& result);
+                                  sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_izamax_sycl)(sycl::queue& queue, std::int64_t n,
                                   sycl::buffer<std::complex<double>, 1>& x, std::int64_t incx,
-                                  sycl::buffer<std::int64_t, 1>& result);
+                                  sycl::buffer<std::int64_t, 1>& result,
+                                  oneapi::math::index_base base);
     void (*row_major_scnrm2_sycl)(sycl::queue& queue, std::int64_t n,
                                   sycl::buffer<std::complex<float>, 1>& x, std::int64_t incx,
                                   sycl::buffer<float, 1>& result);
@@ -3739,31 +3753,35 @@ typedef struct {
                                             const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_isamin_usm_sycl)(sycl::queue& queue, std::int64_t n, const float* x,
                                              std::int64_t incx, std::int64_t* result,
+                                             oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_idamin_usm_sycl)(sycl::queue& queue, std::int64_t n, const double* x,
                                              std::int64_t incx, std::int64_t* result,
+                                             oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_icamin_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                              const std::complex<float>* x, std::int64_t incx,
-                                             std::int64_t* result,
+                                             std::int64_t* result, oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_izamin_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                              const std::complex<double>* x, std::int64_t incx,
-                                             std::int64_t* result,
+                                             std::int64_t* result, oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_isamax_usm_sycl)(sycl::queue& queue, std::int64_t n, const float* x,
                                              std::int64_t incx, std::int64_t* result,
+                                             oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_idamax_usm_sycl)(sycl::queue& queue, std::int64_t n, const double* x,
                                              std::int64_t incx, std::int64_t* result,
+                                             oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_icamax_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                              const std::complex<float>* x, std::int64_t incx,
-                                             std::int64_t* result,
+                                             std::int64_t* result, oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_izamax_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                              const std::complex<double>* x, std::int64_t incx,
-                                             std::int64_t* result,
+                                             std::int64_t* result, oneapi::math::index_base base,
                                              const std::vector<sycl::event>& dependencies);
     sycl::event (*row_major_scnrm2_usm_sycl)(sycl::queue& queue, std::int64_t n,
                                              const std::complex<float>* x, std::int64_t incx,

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1386,26 +1386,36 @@ static int iamax(const int* n, const fp* x, const int* incx, oneapi::math::index
 
 template <>
 int iamax(const int* n, const float* x, const int* incx, oneapi::math::index_base base) {
-    return cblas_isamax_wrapper(*n, x, *incx) + (base == oneapi::math::index_base::zero ? 0 : 1);
+    int res = cblas_isamax_wrapper(*n, x, *incx);
+    if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
+      res++;
+    return res;
 }
 
 template <>
 int iamax(const int* n, const double* x, const int* incx, oneapi::math::index_base base) {
-    return cblas_idamax_wrapper(*n, x, *incx) + (base == oneapi::math::index_base::zero ? 0 : 1);
+    int res = cblas_idamax_wrapper(*n, x, *incx);
+    if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
+      res++;
+    return res;
 }
 
 template <>
 int iamax(const int* n, const std::complex<float>* x, const int* incx,
           oneapi::math::index_base base) {
-    return cblas_icamax_wrapper(*n, (const void*)x, *incx) +
-           (base == oneapi::math::index_base::zero ? 0 : 1);
+    int res = cblas_icamax_wrapper(*n, (const void*)x, *incx);
+    if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
+      res++;
+    return res;
 }
 
 template <>
 int iamax(const int* n, const std::complex<double>* x, const int* incx,
           oneapi::math::index_base base) {
-    return cblas_izamax_wrapper(*n, (const void*)x, *incx) +
-           (base == oneapi::math::index_base::zero ? 0 : 1);
+    int res = cblas_izamax_wrapper(*n, (const void*)x, *incx);
+    if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
+      res++;
+    return res;
 }
 
 inline float abs_val(float val) {

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1386,12 +1386,12 @@ static int iamax(const int* n, const fp* x, const int* incx, oneapi::math::index
 
 template <>
 int iamax(const int* n, const float* x, const int* incx, oneapi::math::index_base base) {
-    return cblas_isamax_wrapper(*n, x, *incx) + base == oneapi::math::index_base::zero ? 0 : 1;
+    return cblas_isamax_wrapper(*n, x, *incx) + (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 template <>
 int iamax(const int* n, const double* x, const int* incx, oneapi::math::index_base base) {
-    return cblas_idamax_wrapper(*n, x, *incx) + base == oneapi::math::index_base::zero ? 0 : 1;
+    return cblas_idamax_wrapper(*n, x, *incx) + (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 template <>
@@ -1449,7 +1449,7 @@ int iamin(const int* n, const float* x, const int* incx, oneapi::math::index_bas
             min_val = curr_val;
         }
     }
-    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
+    return min_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 template <>
@@ -1472,7 +1472,7 @@ int iamin(const int* n, const double* x, const int* incx, oneapi::math::index_ba
             min_val = curr_val;
         }
     }
-    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
+    return min_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 template <>
@@ -1496,7 +1496,7 @@ int iamin(const int* n, const std::complex<float>* x, const int* incx,
             min_val = curr_val;
         }
     }
-    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
+    return min_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 template <>
@@ -1520,7 +1520,7 @@ int iamin(const int* n, const std::complex<double>* x, const int* incx,
             min_val = curr_val;
         }
     }
-    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
+    return min_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 /* Extensions */

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1382,26 +1382,32 @@ void dotu(std::complex<double>* pres, const int* n, const std::complex<double>* 
 }
 
 template <typename fp>
-static int iamax(const int* n, const fp* x, const int* incx);
+static int iamax(const int* n, const fp* x, const int* incx, oneapi::math::index_base base);
 
 template <>
-int iamax(const int* n, const float* x, const int* incx) {
-    return cblas_isamax_wrapper(*n, x, *incx);
+int iamax(const int* n, const float* x, const int* incx, oneapi::math::index_base base) {
+    return cblas_isamax_wrapper(*n, x, *incx) + base == oneapi::math::index_base::zero ? 0 : 1;
 }
 
 template <>
-int iamax(const int* n, const double* x, const int* incx) {
-    return cblas_idamax_wrapper(*n, x, *incx);
+int iamax(const int* n, const double* x, const int* incx, oneapi::math::index_base base) {
+    return cblas_idamax_wrapper(*n, x, *incx) + base == oneapi::math::index_base::zero ? 0 : 1;
 }
 
 template <>
-int iamax(const int* n, const std::complex<float>* x, const int* incx) {
-    return cblas_icamax_wrapper(*n, (const void*)x, *incx);
+int iamax(const int* n, const std::complex<float>* x, const int* incx,
+          oneapi::math::index_base base) {
+    return cblas_icamax_wrapper(*n, (const void*)x, *incx) + base == oneapi::math::index_base::zero
+               ? 0
+               : 1;
 }
 
 template <>
-int iamax(const int* n, const std::complex<double>* x, const int* incx) {
-    return cblas_izamax_wrapper(*n, (const void*)x, *incx);
+int iamax(const int* n, const std::complex<double>* x, const int* incx,
+          oneapi::math::index_base base) {
+    return cblas_izamax_wrapper(*n, (const void*)x, *incx) + base == oneapi::math::index_base::zero
+               ? 0
+               : 1;
 }
 
 inline float abs_val(float val) {
@@ -1421,10 +1427,10 @@ inline double abs_val(std::complex<double> val) {
 }
 
 template <typename fp>
-static int iamin(const int* n, const fp* x, const int* incx);
+static int iamin(const int* n, const fp* x, const int* incx, oneapi::math::index_base base);
 
 template <>
-int iamin(const int* n, const float* x, const int* incx) {
+int iamin(const int* n, const float* x, const int* incx, oneapi::math::index_base base) {
     if (*n < 1 || *incx < 1) {
         return 0;
     }
@@ -1443,11 +1449,11 @@ int iamin(const int* n, const float* x, const int* incx) {
             min_val = curr_val;
         }
     }
-    return min_idx;
+    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
 }
 
 template <>
-int iamin(const int* n, const double* x, const int* incx) {
+int iamin(const int* n, const double* x, const int* incx, oneapi::math::index_base base) {
     if (*n < 1 || *incx < 1) {
         return 0;
     }
@@ -1466,11 +1472,12 @@ int iamin(const int* n, const double* x, const int* incx) {
             min_val = curr_val;
         }
     }
-    return min_idx;
+    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
 }
 
 template <>
-int iamin(const int* n, const std::complex<float>* x, const int* incx) {
+int iamin(const int* n, const std::complex<float>* x, const int* incx,
+          oneapi::math::index_base base) {
     if (*n < 1 || *incx < 1) {
         return 0;
     }
@@ -1489,11 +1496,12 @@ int iamin(const int* n, const std::complex<float>* x, const int* incx) {
             min_val = curr_val;
         }
     }
-    return min_idx;
+    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
 }
 
 template <>
-int iamin(const int* n, const std::complex<double>* x, const int* incx) {
+int iamin(const int* n, const std::complex<double>* x, const int* incx,
+          oneapi::math::index_base base) {
     if (*n < 1 || *incx < 1) {
         return 0;
     }
@@ -1512,7 +1520,7 @@ int iamin(const int* n, const std::complex<double>* x, const int* incx) {
             min_val = curr_val;
         }
     }
-    return min_idx;
+    return min_idx + base == oneapi::math::index_base::zero ? 0 : 1;
 }
 
 /* Extensions */

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1397,17 +1397,15 @@ int iamax(const int* n, const double* x, const int* incx, oneapi::math::index_ba
 template <>
 int iamax(const int* n, const std::complex<float>* x, const int* incx,
           oneapi::math::index_base base) {
-    return cblas_icamax_wrapper(*n, (const void*)x, *incx) + base == oneapi::math::index_base::zero
-               ? 0
-               : 1;
+    return cblas_icamax_wrapper(*n, (const void*)x, *incx) +
+           (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 template <>
 int iamax(const int* n, const std::complex<double>* x, const int* incx,
           oneapi::math::index_base base) {
-    return cblas_izamax_wrapper(*n, (const void*)x, *incx) + base == oneapi::math::index_base::zero
-               ? 0
-               : 1;
+    return cblas_izamax_wrapper(*n, (const void*)x, *incx) +
+           (base == oneapi::math::index_base::zero ? 0 : 1);
 }
 
 inline float abs_val(float val) {

--- a/tests/unit_tests/blas/include/reference_blas_templates.hpp
+++ b/tests/unit_tests/blas/include/reference_blas_templates.hpp
@@ -1388,7 +1388,7 @@ template <>
 int iamax(const int* n, const float* x, const int* incx, oneapi::math::index_base base) {
     int res = cblas_isamax_wrapper(*n, x, *incx);
     if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
-      res++;
+        res++;
     return res;
 }
 
@@ -1396,7 +1396,7 @@ template <>
 int iamax(const int* n, const double* x, const int* incx, oneapi::math::index_base base) {
     int res = cblas_idamax_wrapper(*n, x, *incx);
     if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
-      res++;
+        res++;
     return res;
 }
 
@@ -1405,7 +1405,7 @@ int iamax(const int* n, const std::complex<float>* x, const int* incx,
           oneapi::math::index_base base) {
     int res = cblas_icamax_wrapper(*n, (const void*)x, *incx);
     if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
-      res++;
+        res++;
     return res;
 }
 
@@ -1414,7 +1414,7 @@ int iamax(const int* n, const std::complex<double>* x, const int* incx,
           oneapi::math::index_base base) {
     int res = cblas_izamax_wrapper(*n, (const void*)x, *incx);
     if (base == oneapi::math::index_base::one && *n >= 1 && *incx >= 1)
-      res++;
+        res++;
     return res;
 }
 

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -130,7 +130,7 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx, oneapi::math
 class IamaxTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
-TEST_P(IamaxTests, RealSinglePrecisionBaseZero) {
+TEST_P(IamaxTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
                                   oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
@@ -146,7 +146,7 @@ TEST_P(IamaxTests, RealSinglePrecisionBaseOne) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::one));
 }
-TEST_P(IamaxTests, RealDoublePrecisionBaseZero) {
+TEST_P(IamaxTests, RealDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
@@ -156,17 +156,7 @@ TEST_P(IamaxTests, RealDoublePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                    oneapi::math::index_base::zero));
 }
-TEST_P(IamaxTests, RealDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
-                                   oneapi::math::index_base::one));
-}
-TEST_P(IamaxTests, ComplexSinglePrecisionBaseZero) {
+TEST_P(IamaxTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, 2, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -174,15 +164,7 @@ TEST_P(IamaxTests, ComplexSinglePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, -3, oneapi::math::index_base::zero));
 }
-TEST_P(IamaxTests, ComplexSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, -3, oneapi::math::index_base::one));
-}
-TEST_P(IamaxTests, ComplexDoublePrecisionBaseZero) {
+TEST_P(IamaxTests, ComplexDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -191,16 +173,6 @@ TEST_P(IamaxTests, ComplexDoublePrecisionBaseZero) {
                                                  1357, 1, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  1357, -3, oneapi::math::index_base::zero));
-}
-TEST_P(IamaxTests, ComplexDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, -3, oneapi::math::index_base::one));
 }
 
 INSTANTIATE_TEST_SUITE_P(IamaxTestSuite, IamaxTests,

--- a/tests/unit_tests/blas/level1/iamax.cpp
+++ b/tests/unit_tests/blas/level1/iamax.cpp
@@ -137,13 +137,9 @@ TEST_P(IamaxTests, RealSinglePrecision) {
                                   oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::zero));
-}
-TEST_P(IamaxTests, RealSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                  oneapi::math::index_base::one));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -1,
                                   oneapi::math::index_base::one));
 }
 TEST_P(IamaxTests, RealDoublePrecision) {

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -46,7 +46,7 @@ extern std::vector<sycl::device*> devices;
 namespace {
 
 template <typename fp, usm::alloc alloc_type = usm::alloc::shared>
-int test(device* dev, oneapi::math::layout layout, int N, int incx) {
+int test(device* dev, oneapi::math::layout layout, int N, int incx, oneapi::math::index_base base) {
     // Catch asynchronous exceptions.
     auto exception_handler = [](exception_list exceptions) {
         for (std::exception_ptr const& e : exceptions) {
@@ -76,7 +76,7 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
     using fp_ref = typename ref_type_info<fp>::type;
     const int N_ref = N, incx_ref = incx;
 
-    result_ref = ::iamax(&N_ref, (fp_ref*)x.data(), &incx_ref);
+    result_ref = ::iamax(&N_ref, (fp_ref*)x.data(), &incx_ref, base);
 
     // Call DPC++ IAMAX.
 
@@ -96,11 +96,11 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
         switch (layout) {
             case oneapi::math::layout::col_major:
                 done = oneapi::math::blas::column_major::iamax(main_queue, N, x.data(), incx,
-                                                               result_p, dependencies);
+                                                               result_p, base, dependencies);
                 break;
             case oneapi::math::layout::row_major:
                 done = oneapi::math::blas::row_major::iamax(main_queue, N, x.data(), incx, result_p,
-                                                            dependencies);
+                                                            base, dependencies);
                 break;
             default: break;
         }
@@ -109,11 +109,11 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
         switch (layout) {
             case oneapi::math::layout::col_major:
                 TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::math::blas::column_major::iamax, N,
-                                        x.data(), incx, result_p, dependencies);
+                                        x.data(), incx, result_p, base, dependencies);
                 break;
             case oneapi::math::layout::row_major:
                 TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::math::blas::row_major::iamax, N,
-                                        x.data(), incx, result_p, dependencies);
+                                        x.data(), incx, result_p, base, dependencies);
                 break;
             default: break;
         }
@@ -144,43 +144,93 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
 class IamaxUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
-TEST_P(IamaxUsmTests, RealSinglePrecision) {
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP((
-        test<float, usm::alloc::device>(std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+TEST_P(IamaxUsmTests, RealSinglePrecisionBaseZero) {
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                  oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                  oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                  oneapi::math::index_base::zero));
 }
-TEST_P(IamaxUsmTests, RealDoublePrecision) {
+TEST_P(IamaxUsmTests, RealSinglePrecisionBaseOne) {
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                  oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                  oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                  oneapi::math::index_base::one));
+}
+TEST_P(IamaxUsmTests, RealDoublePrecisionBaseZero) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(std::get<0>(GetParam()),
-                                                        std::get<1>(GetParam()), 101, 1)));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                   oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                   oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                   oneapi::math::index_base::zero));
 }
-TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
-    EXPECT_TRUEORSKIP(
-        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+TEST_P(IamaxUsmTests, RealDoublePrecisionBaseOne) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                   oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                   oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                   oneapi::math::index_base::one));
+}
+TEST_P(IamaxUsmTests, ComplexSinglePrecisionBaseZero) {
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 2, oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 1, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP((test<std::complex<float>, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, -3, oneapi::math::index_base::zero));
 }
-TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
+TEST_P(IamaxUsmTests, ComplexSinglePrecisionBaseOne) {
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 2, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 1, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP((test<std::complex<float>, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, -3, oneapi::math::index_base::one));
+}
+TEST_P(IamaxUsmTests, ComplexDoublePrecisionBaseZero) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
-    EXPECT_TRUEORSKIP(
-        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 2, oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 1, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP((test<std::complex<double>, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1)));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, -3, oneapi::math::index_base::zero));
+}
+TEST_P(IamaxUsmTests, ComplexDoublePrecisionBaseOne) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 2, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 1, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP((test<std::complex<double>, usm::alloc::device>(
+        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, -3, oneapi::math::index_base::one));
 }
 
 INSTANTIATE_TEST_SUITE_P(IamaxUsmTestSuite, IamaxUsmTests,

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -144,7 +144,7 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx, oneapi::math
 class IamaxUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
-TEST_P(IamaxUsmTests, RealSinglePrecisionBaseZero) {
+TEST_P(IamaxUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
                                   oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
@@ -164,7 +164,7 @@ TEST_P(IamaxUsmTests, RealSinglePrecisionBaseOne) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::one));
 }
-TEST_P(IamaxUsmTests, RealDoublePrecisionBaseZero) {
+TEST_P(IamaxUsmTests, RealDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
@@ -176,19 +176,7 @@ TEST_P(IamaxUsmTests, RealDoublePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                    oneapi::math::index_base::zero));
 }
-TEST_P(IamaxUsmTests, RealDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
-                                   oneapi::math::index_base::one));
-}
-TEST_P(IamaxUsmTests, ComplexSinglePrecisionBaseZero) {
+TEST_P(IamaxUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, 2, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -198,17 +186,7 @@ TEST_P(IamaxUsmTests, ComplexSinglePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, -3, oneapi::math::index_base::zero));
 }
-TEST_P(IamaxUsmTests, ComplexSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<std::complex<float>, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, -3, oneapi::math::index_base::one));
-}
-TEST_P(IamaxUsmTests, ComplexDoublePrecisionBaseZero) {
+TEST_P(IamaxUsmTests, ComplexDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -219,18 +197,6 @@ TEST_P(IamaxUsmTests, ComplexDoublePrecisionBaseZero) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  1357, -3, oneapi::math::index_base::zero));
-}
-TEST_P(IamaxUsmTests, ComplexDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<std::complex<double>, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, -3, oneapi::math::index_base::one));
 }
 
 INSTANTIATE_TEST_SUITE_P(IamaxUsmTestSuite, IamaxUsmTests,

--- a/tests/unit_tests/blas/level1/iamax_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamax_usm.cpp
@@ -153,15 +153,9 @@ TEST_P(IamaxUsmTests, RealSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::zero));
-}
-TEST_P(IamaxUsmTests, RealSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                  oneapi::math::index_base::one));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -1,
                                   oneapi::math::index_base::one));
 }
 TEST_P(IamaxUsmTests, RealDoublePrecision) {

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -46,7 +46,7 @@ extern std::vector<sycl::device*> devices;
 namespace {
 
 template <typename fp>
-int test(device* dev, oneapi::math::layout layout, int N, int incx) {
+int test(device* dev, oneapi::math::layout layout, int N, int incx, oneapi::math::index_base base) {
     // Prepare data.
     vector<fp> x;
     int64_t result = -1, result_ref = -1;
@@ -56,7 +56,7 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
     using fp_ref = typename ref_type_info<fp>::type;
     const int N_ref = N, incx_ref = incx;
 
-    result_ref = ::iamin(&N_ref, (fp_ref*)x.data(), &incx_ref);
+    result_ref = ::iamin(&N_ref, (fp_ref*)x.data(), &incx_ref, base);
 
     // Call DPC++ IAMIN.
 
@@ -84,10 +84,11 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
         switch (layout) {
             case oneapi::math::layout::col_major:
                 oneapi::math::blas::column_major::iamin(main_queue, N, x_buffer, incx,
-                                                        result_buffer);
+                                                        result_buffer, base);
                 break;
             case oneapi::math::layout::row_major:
-                oneapi::math::blas::row_major::iamin(main_queue, N, x_buffer, incx, result_buffer);
+                oneapi::math::blas::row_major::iamin(main_queue, N, x_buffer, incx, result_buffer,
+                                                     base);
                 break;
             default: break;
         }
@@ -95,11 +96,11 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
         switch (layout) {
             case oneapi::math::layout::col_major:
                 TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::math::blas::column_major::iamin, N,
-                                        x_buffer, incx, result_buffer);
+                                        x_buffer, incx, result_buffer, base);
                 break;
             case oneapi::math::layout::row_major:
                 TEST_RUN_BLAS_CT_SELECT(main_queue, oneapi::math::blas::row_major::iamin, N,
-                                        x_buffer, incx, result_buffer);
+                                        x_buffer, incx, result_buffer, base);
                 break;
             default: break;
         }
@@ -129,35 +130,77 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx) {
 class IaminTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
-TEST_P(IaminTests, RealSinglePrecision) {
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+TEST_P(IaminTests, RealSinglePrecisionBaseZero) {
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                  oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                  oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                  oneapi::math::index_base::zero));
 }
-TEST_P(IaminTests, RealDoublePrecision) {
+TEST_P(IaminTests, RealSinglePrecisionBaseOne) {
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                  oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                  oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                  oneapi::math::index_base::one));
+}
+TEST_P(IaminTests, RealDoublePrecisionBaseZero) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                   oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                   oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                   oneapi::math::index_base::zero));
 }
-TEST_P(IaminTests, ComplexSinglePrecision) {
-    EXPECT_TRUEORSKIP(
-        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
-}
-TEST_P(IaminTests, ComplexDoublePrecision) {
+TEST_P(IaminTests, RealDoublePrecisionBaseOne) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
-    EXPECT_TRUEORSKIP(
-        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1));
-    EXPECT_TRUEORSKIP(
-        test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
+                                   oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
+                                   oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+                                   oneapi::math::index_base::one));
+}
+TEST_P(IaminTests, ComplexSinglePrecisionBaseZero) {
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 2, oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 1, oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, -3, oneapi::math::index_base::zero));
+}
+TEST_P(IaminTests, ComplexSinglePrecisionBaseOne) {
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 2, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, 1, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                1357, -3, oneapi::math::index_base::one));
+}
+TEST_P(IaminTests, ComplexDoublePrecisionBaseZero) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 2, oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 1, oneapi::math::index_base::zero));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, -3, oneapi::math::index_base::zero));
+}
+TEST_P(IaminTests, ComplexDoublePrecisionBaseOne) {
+    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
+
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 2, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, 1, oneapi::math::index_base::one));
+    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
+                                                 1357, -3, oneapi::math::index_base::one));
 }
 
 INSTANTIATE_TEST_SUITE_P(IaminTestSuite, IaminTests,

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -137,13 +137,9 @@ TEST_P(IaminTests, RealSinglePrecision) {
                                   oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::zero));
-}
-TEST_P(IaminTests, RealSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                  oneapi::math::index_base::one));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -1,
                                   oneapi::math::index_base::one));
 }
 TEST_P(IaminTests, RealDoublePrecision) {

--- a/tests/unit_tests/blas/level1/iamin.cpp
+++ b/tests/unit_tests/blas/level1/iamin.cpp
@@ -130,7 +130,7 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx, oneapi::math
 class IaminTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
-TEST_P(IaminTests, RealSinglePrecisionBaseZero) {
+TEST_P(IaminTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
                                   oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
@@ -146,7 +146,7 @@ TEST_P(IaminTests, RealSinglePrecisionBaseOne) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::one));
 }
-TEST_P(IaminTests, RealDoublePrecisionBaseZero) {
+TEST_P(IaminTests, RealDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
@@ -156,17 +156,7 @@ TEST_P(IaminTests, RealDoublePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                    oneapi::math::index_base::zero));
 }
-TEST_P(IaminTests, RealDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
-                                   oneapi::math::index_base::one));
-}
-TEST_P(IaminTests, ComplexSinglePrecisionBaseZero) {
+TEST_P(IaminTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, 2, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -174,15 +164,7 @@ TEST_P(IaminTests, ComplexSinglePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, -3, oneapi::math::index_base::zero));
 }
-TEST_P(IaminTests, ComplexSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, -3, oneapi::math::index_base::one));
-}
-TEST_P(IaminTests, ComplexDoublePrecisionBaseZero) {
+TEST_P(IaminTests, ComplexDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -191,16 +173,6 @@ TEST_P(IaminTests, ComplexDoublePrecisionBaseZero) {
                                                  1357, 1, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  1357, -3, oneapi::math::index_base::zero));
-}
-TEST_P(IaminTests, ComplexDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, -3, oneapi::math::index_base::one));
 }
 
 INSTANTIATE_TEST_SUITE_P(IaminTestSuite, IaminTests,

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -144,7 +144,7 @@ int test(device* dev, oneapi::math::layout layout, int N, int incx, oneapi::math
 class IaminUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {};
 
-TEST_P(IaminUsmTests, RealSinglePrecisionBaseZero) {
+TEST_P(IaminUsmTests, RealSinglePrecision) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
                                   oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
@@ -164,7 +164,7 @@ TEST_P(IaminUsmTests, RealSinglePrecisionBaseOne) {
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::one));
 }
-TEST_P(IaminUsmTests, RealDoublePrecisionBaseZero) {
+TEST_P(IaminUsmTests, RealDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
@@ -176,19 +176,7 @@ TEST_P(IaminUsmTests, RealDoublePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                    oneapi::math::index_base::zero));
 }
-TEST_P(IaminUsmTests, RealDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
-                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<double, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<double>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
-                                   oneapi::math::index_base::one));
-}
-TEST_P(IaminUsmTests, ComplexSinglePrecisionBaseZero) {
+TEST_P(IaminUsmTests, ComplexSinglePrecision) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, 2, oneapi::math::index_base::zero));
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -198,17 +186,7 @@ TEST_P(IaminUsmTests, ComplexSinglePrecisionBaseZero) {
     EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                 1357, -3, oneapi::math::index_base::zero));
 }
-TEST_P(IaminUsmTests, ComplexSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<std::complex<float>, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<std::complex<float>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                1357, -3, oneapi::math::index_base::one));
-}
-TEST_P(IaminUsmTests, ComplexDoublePrecisionBaseZero) {
+TEST_P(IaminUsmTests, ComplexDoublePrecision) {
     CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
 
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
@@ -219,18 +197,6 @@ TEST_P(IaminUsmTests, ComplexDoublePrecisionBaseZero) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
     EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
                                                  1357, -3, oneapi::math::index_base::zero));
-}
-TEST_P(IaminUsmTests, ComplexDoublePrecisionBaseOne) {
-    CHECK_DOUBLE_ON_DEVICE(std::get<0>(GetParam()));
-
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 2, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, 1, oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<std::complex<double>, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<std::complex<double>>(std::get<0>(GetParam()), std::get<1>(GetParam()),
-                                                 1357, -3, oneapi::math::index_base::one));
 }
 
 INSTANTIATE_TEST_SUITE_P(IaminUsmTestSuite, IaminUsmTests,

--- a/tests/unit_tests/blas/level1/iamin_usm.cpp
+++ b/tests/unit_tests/blas/level1/iamin_usm.cpp
@@ -153,15 +153,9 @@ TEST_P(IaminUsmTests, RealSinglePrecision) {
         std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::zero)));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
                                   oneapi::math::index_base::zero));
-}
-TEST_P(IaminUsmTests, RealSinglePrecisionBaseOne) {
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 2,
-                                  oneapi::math::index_base::one));
     EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, 1,
                                   oneapi::math::index_base::one));
-    EXPECT_TRUEORSKIP((test<float, usm::alloc::device>(
-        std::get<0>(GetParam()), std::get<1>(GetParam()), 101, 1, oneapi::math::index_base::one)));
-    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -3,
+    EXPECT_TRUEORSKIP(test<float>(std::get<0>(GetParam()), std::get<1>(GetParam()), 1357, -1,
                                   oneapi::math::index_base::one));
 }
 TEST_P(IaminUsmTests, RealDoublePrecision) {


### PR DESCRIPTION
# Description

In the spec [iamax](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/blas/iamax) and [iamin](https://oneapi-spec.uxlfoundation.org/specifications/oneapi/v1.4-rev-1/elements/onemath/source/domains/blas/iamin) can accept an oneapi::mkl::index_base argument.
But in the current impl, there is no such parameter in the function declaration.

Fixes #591

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.
Only run related tests by `ctest -R Iam`
[cublas.txt](https://github.com/user-attachments/files/18902194/cublas.txt)
[generic.txt](https://github.com/user-attachments/files/18902195/generic.txt)
[mklcpu.txt](https://github.com/user-attachments/files/18902196/mklcpu.txt)
[netlib.txt](https://github.com/user-attachments/files/18902197/netlib.txt)
No env to test Arm and Roc backends.

## Bug fixes

- [X] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
