### PR TITLE
[cmake] Allow to use clang++ -fsycl

### DIFF
--- a/cmake/FindCompiler.cmake
+++ b/cmake/FindCompiler.cmake
@@ -25,7 +25,14 @@ check_cxx_compiler_flag("-fsycl" is_dpcpp)
 if(is_dpcpp)
   # Workaround for internal compiler error during linking if -fsycl is used
   get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
-  find_library(SYCL_LIBRARY NAMES sycl PATHS "${SYCL_BINARY_DIR}/../lib" "${SYCL_BINARY_DIR}/lib" ENV LIBRARY_PATH ENV PATH)
+  find_library(SYCL_LIBRARY NAMES sycl
+    PATHS
+      "${SYCL_BINARY_DIR}/lib"
+      "${SYCL_BINARY_DIR}/../lib"
+      "${SYCL_BINARY_DIR}/../../lib"
+      ENV LIBRARY_PATH
+      ENV PATH
+  )
   if(NOT SYCL_LIBRARY)
     message(FATAL_ERROR "SYCL library is not found in ${SYCL_BINARY_DIR}/../lib, PATH, and LIBRARY_PATH")
   endif()

--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -24,9 +24,9 @@ get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 find_path(OPENCL_INCLUDE_DIR
   NAMES CL/cl.h OpenCL/cl.h
   HINTS
-  ${OPENCL_INCLUDE_DIR}
-  ${SYCL_BINARY_DIR}/../include/
-  ${SYCL_BINARY_DIR}/../../include/
+    ${OPENCL_INCLUDE_DIR}
+    ${SYCL_BINARY_DIR}/../include/
+    ${SYCL_BINARY_DIR}/../../include/
   PATH_SUFFIXES sycl
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL

--- a/cmake/FindcuBLAS.cmake
+++ b/cmake/FindcuBLAS.cmake
@@ -21,12 +21,13 @@ find_package(CUDA 10.0 REQUIRED)
 get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 # the OpenCL include file from cuda is opencl 1.1 and it is not compatible with DPC++
 # the OpenCL include headers 1.2 onward is required. This is used to bypass NVIDIA OpenCL headers
-find_path(OPENCL_INCLUDE_DIR CL/cl.h OpenCL/cl.h 
-HINTS 
-${OPENCL_INCLUDE_DIR}
-${SYCL_BINARY_DIR}/../include/sycl/
-${SYCL_BINARY_DIR}/../../include/sycl/
-${SYCL_BINARY_DIR}/../include/
+find_path(OPENCL_INCLUDE_DIR
+  NAMES CL/cl.h OpenCL/cl.h
+  HINTS
+  ${OPENCL_INCLUDE_DIR}
+  ${SYCL_BINARY_DIR}/../include/
+  ${SYCL_BINARY_DIR}/../../include/
+  PATH_SUFFIXES sycl
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)

--- a/cmake/FindcuRAND.cmake
+++ b/cmake/FindcuRAND.cmake
@@ -62,11 +62,13 @@ get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 if (NOT (ONEMATH_SYCL_IMPLEMENTATION STREQUAL "hipsycl"))
 # the OpenCL include file from cuda is opencl 1.1 and it is not compatible with DPC++
 # the OpenCL include headers 1.2 onward is required. This is used to bypass NVIDIA OpenCL headers
-find_path(OPENCL_INCLUDE_DIR CL/cl.h OpenCL/cl.h 
-HINTS 
-${OPENCL_INCLUDE_DIR}
-${SYCL_BINARY_DIR}/../include/sycl/
-${SYCL_BINARY_DIR}/../include/
+find_path(OPENCL_INCLUDE_DIR
+  NAMES CL/cl.h OpenCL/cl.h
+  HINTS
+  ${OPENCL_INCLUDE_DIR}
+  ${SYCL_BINARY_DIR}/../include/
+  ${SYCL_BINARY_DIR}/../../include/
+  PATH_SUFFIXES sycl
 )
 endif()
 

--- a/cmake/FindcuRAND.cmake
+++ b/cmake/FindcuRAND.cmake
@@ -65,9 +65,9 @@ if (NOT (ONEMATH_SYCL_IMPLEMENTATION STREQUAL "hipsycl"))
 find_path(OPENCL_INCLUDE_DIR
   NAMES CL/cl.h OpenCL/cl.h
   HINTS
-  ${OPENCL_INCLUDE_DIR}
-  ${SYCL_BINARY_DIR}/../include/
-  ${SYCL_BINARY_DIR}/../../include/
+    ${OPENCL_INCLUDE_DIR}
+    ${SYCL_BINARY_DIR}/../include/
+    ${SYCL_BINARY_DIR}/../../include/
   PATH_SUFFIXES sycl
 )
 endif()

--- a/cmake/FindcuSOLVER.cmake
+++ b/cmake/FindcuSOLVER.cmake
@@ -21,11 +21,13 @@ find_package(CUDA 10.0 REQUIRED)
 get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 # the OpenCL include file from cuda is opencl 1.1 and it is not compatible with DPC++
 # the OpenCL include headers 1.2 onward is required. This is used to bypass NVIDIA OpenCL headers
-find_path(OPENCL_INCLUDE_DIR CL/cl.h OpenCL/cl.h 
-HINTS 
-${OPENCL_INCLUDE_DIR}
-${SYCL_BINARY_DIR}/../include/sycl/
-${SYCL_BINARY_DIR}/../include/
+find_path(OPENCL_INCLUDE_DIR
+  NAMES CL/cl.h OpenCL/cl.h
+  HINTS
+  ${OPENCL_INCLUDE_DIR}
+  ${SYCL_BINARY_DIR}/../include/
+  ${SYCL_BINARY_DIR}/../../include/
+  PATH_SUFFIXES sycl
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL
 add_compile_definitions(CUDA_NO_HALF)

--- a/cmake/FindcuSOLVER.cmake
+++ b/cmake/FindcuSOLVER.cmake
@@ -24,9 +24,9 @@ get_filename_component(SYCL_BINARY_DIR ${CMAKE_CXX_COMPILER} DIRECTORY)
 find_path(OPENCL_INCLUDE_DIR
   NAMES CL/cl.h OpenCL/cl.h
   HINTS
-  ${OPENCL_INCLUDE_DIR}
-  ${SYCL_BINARY_DIR}/../include/
-  ${SYCL_BINARY_DIR}/../../include/
+    ${OPENCL_INCLUDE_DIR}
+    ${SYCL_BINARY_DIR}/../include/
+    ${SYCL_BINARY_DIR}/../../include/
   PATH_SUFFIXES sycl
 )
 # this is work around to avoid duplication half creation in both cuda and SYCL


### PR DESCRIPTION
Update paths to allowing CMake finding components as clang++ is one directory deeper than icpx:
* Fix find_path to OpenCL headers
  * Use `NAMES` to properly specify that `OpenCL/cl.h` is an alternative and not a hint
  * Add a path to look 2 directories above `bin/compiler`
  * Use `PATH_SUFFIXES` to avoid repeating the `sycl` directory
* Fix find_library to SYCL runtime
  * Add a path to look 2 directories above `bin/compiler`

# Description

The changes allow setting `clang++` built from intel/llvm as the CXX compiler while still automatically finding the SYCL runtime and corresponding OpenCL headers.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally?
  - Logs running on A100 using the release compiler: [onemath_cuda.txt](https://github.com/user-attachments/files/19055873/onemath_cuda.txt)
  - Logs running on A100 using clang++: [onemath_cuda_nightly.txt](https://github.com/user-attachments/files/19055875/onemath_cuda_nightly.txt)