### PR TITLE
Bump action/cache to v4.2.2

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -63,7 +63,7 @@ jobs:
          return domainCheck({github, context, domain: "${{ matrix.domain }}"})
     - name: Restore netlib from cache
       id: cache-lapack
-      uses: actions/cache@0c45773b623bea8c8e75f6c82b208c3cf94ea4f9 # v4.0.2
+      uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4.2.2
       with:
         path: lapack/install
         key: lapack-${{ env.LAPACK_VERSION }}


### PR DESCRIPTION
# Description

Update dependency needed to run the CI on PRs. The CI cannot run without this update, see for instance https://github.com/uxlfoundation/oneMath/pull/639 ([job](https://github.com/uxlfoundation/oneMath/actions/runs/13634820134/job/38110846969?pr=639))

This is the latest version from [action/cache](https://github.com/actions/cache).