### PR TITLE
[blas][dft][generic] Fix macro for generic backend to enable generic device

### DIFF
--- a/include/oneapi/math/detail/backends_table.hpp
+++ b/include/oneapi/math/detail/backends_table.hpp
@@ -95,7 +95,7 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
           } },
         { device::generic_device,
           {
-#ifdef ENABLE_GENERIC_BLAS_BACKEND
+#ifdef ONEMATH_ENABLE_GENERIC_BLAS_BACKEND
               LIB_NAME("blas_generic"),
 #endif
           } } } },
@@ -139,7 +139,7 @@ static std::map<domain, std::map<device, std::vector<const char*>>> libraries = 
           } },
         { device::generic_device,
           {
-#ifdef ENABLE_PORTFFT_BACKEND
+#ifdef ONEMATH_ENABLE_PORTFFT_BACKEND
               LIB_NAME("dft_portfft"),
 #endif
           } } } },

--- a/src/include/function_table_initializer.hpp
+++ b/src/include/function_table_initializer.hpp
@@ -67,7 +67,7 @@ public:
     }
 
 private:
-#if defined(ENABLE_GENERIC_BLAS_BACKEND) || defined(ENABLE_PORTFFT_BACKEND)
+#if defined(ONEMATH_ENABLE_GENERIC_BLAS_BACKEND) || defined(ONEMATH_ENABLE_PORTFFT_BACKEND)
     static constexpr bool is_generic_device_supported = true;
 #else
     static constexpr bool is_generic_device_supported = false;


### PR DESCRIPTION
# Description

This PR fixes a bug with enablement macros for generic backend devices which vendor is not known to us yet.
It occurs after renaming to oneMath since these macros weren't renamed.

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
    - [intel_igpu_generic_log.txt](https://github.com/user-attachments/files/19319216/intel_gpu_log.txt)
    -  [nvidia_generic_log.txt](https://github.com/user-attachments/files/19319222/nvidia_generic_log.txt)

## Bug fixes

- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
To test it properly you need a GPU that is neither Intel, NVIDIA or AMD