### PR TITLE
[cuBLAS][rocBLAS] Fix uninstantiated template static asserts for older compilers

### DIFF
--- a/src/blas/backends/cublas/cublas_helper.hpp
+++ b/src/blas/backends/cublas/cublas_helper.hpp
@@ -260,7 +260,7 @@ inline cublasSideMode_t get_cublas_side_mode(oneapi::math::side lr) {
 
 template <typename T>
 inline cudaDataType_t get_cublas_datatype() {
-    static_assert(false);
+    static_assert(sizeof(T) && false, "Type T has no corresponding cuBLAS type");
 }
 
 template <>

--- a/src/blas/backends/rocblas/rocblas_helper.hpp
+++ b/src/blas/backends/rocblas/rocblas_helper.hpp
@@ -218,7 +218,7 @@ inline rocblas_side get_rocblas_side_mode(oneapi::math::side lr) {
 
 template <typename T>
 inline rocblas_datatype get_rocblas_datatype() {
-    static_assert(false);
+    static_assert(sizeof(T) && false, "Type T has no corresponding rocBLAS type");
 }
 
 template <>


### PR DESCRIPTION
[CWG2518](https://cplusplus.github.io/CWG/issues/2518.html) allowing `static_assert(false)` in uninstantiated template is a [C++23 behaviour](https://en.cppreference.com/w/cpp/23) that happens to work regardless of `-std` flag in recent compilers (clang >= 17) including DPC++. However, AdaptiveCpp is based on an older clang version and does not support that.

Force the static assert evaluation to be pushed after template evaluations by using type T inside the expression. This works in all supported compilers. Also add a message in the assert to clarify why it's there.

Credits to @DuncanMcBain for the solution.

Fixes #617