### PR TITLE
[BLAS][generic] Support CMake option to provide local source dir

### DIFF
--- a/docs/building_the_project_with_dpcpp.rst
+++ b/docs/building_the_project_with_dpcpp.rst
@@ -275,7 +275,10 @@ Building for oneMath generic SYCL BLAS
 --------------------------------------
 
 `onemath generic SYCL BLAS <https://github.com/uxlfoundation/generic-sycl-components/tree/main/onemath/sycl/blas>`_
-is enabled by setting ``-DENABLE_GENERIC_BLAS_BACKEND=True``.
+is enabled by setting ``-DENABLE_GENERIC_BLAS_BACKEND=True``. By default, the
+source code is downloaded automatically from GitHub during CMake configuration.
+To use a local checkout of the source code instead, use the
+``-DONEMATH_SYCL_BLAS_SOURCE_DIR=<path>`` option.
 
 By default, the generic BLAS backend is not tuned for any specific device.
 This tuning is required to achieve best performance.

--- a/src/blas/backends/generic/CMakeLists.txt
+++ b/src/blas/backends/generic/CMakeLists.txt
@@ -138,34 +138,44 @@ else()
   message(STATUS "generic BLAS is not tuned for any device which can impact performance")
 endif()
 
-# If find_package doesn't work, download onemath_sycl_blas from Github. This is
-# intended to make oneMath easier to use.
+# Try the following ways of finding onemath_sycl_blas:
+# 1. find_package
+# 2. source directory given in the ONEMATH_SYCL_BLAS_SOURCE_DIR variable
+# 3. FetchContent from github
 message(STATUS "Looking for oneMATH blas kernels")
 find_package(ONEMATH_SYCL_BLAS QUIET)
-if (NOT ONEMATH_SYCL_BLAS_FOUND)
-  message(STATUS "Looking for onemath_sycl_blas for generic backend - could not find onemath_sycl_blas with ONEMATH_SYCL_BLAS_DIR")
-  include(FetchContent)
+if (ONEMATH_SYCL_BLAS_FOUND)
+  message(STATUS "Looking for oneMath blas kernels - found")
+  add_library(onemath_sycl_blas ALIAS ONEMATH_SYCL_BLAS::onemath_sycl_blas)
+else()
   if(NOT GENERIC_BLAS_TUNING_TARGET)
     set(GENERIC_BLAS_TUNING_TARGET "DEFAULT")
   endif()
   # Following variable TUNING_TARGET will be used in generic blas internal configuration
   set(TUNING_TARGET ${GENERIC_BLAS_TUNING_TARGET})
-  set(BLAS_ENABLE_COMPLEX ON)
   # Set the policy to forward variables to generic blas configure step
   set(CMAKE_POLICY_DEFAULT_CMP0077 NEW)
-  set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}/deps")
-  FetchContent_Declare(
-    onemath_sycl_blas
-    GIT_REPOSITORY https://github.com/uxlfoundation/generic-sycl-components
-    GIT_TAG        main
-    SOURCE_SUBDIR onemath/sycl/blas
-  )
-  FetchContent_MakeAvailable(onemath_sycl_blas)
-  message(STATUS "Looking for onemath_sycl_blas - downloaded")
 
-else()
-  message(STATUS "Looking for oneMath blas kernels - found")
-  add_library(onemath_sycl_blas ALIAS ONEMATH_SYCL_BLAS::onemath_sycl_blas)
+  if (ONEMATH_SYCL_BLAS_SOURCE_DIR AND IS_DIRECTORY "${ONEMATH_SYCL_BLAS_SOURCE_DIR}")
+    message(STATUS "Looking for onemath_sycl_blas for generic backend "
+            "- using ONEMATH_SYCL_BLAS_SOURCE_DIR=${ONEMATH_SYCL_BLAS_SOURCE_DIR}")
+    add_subdirectory(${ONEMATH_SYCL_BLAS_SOURCE_DIR}
+                     ${CMAKE_CURRENT_BINARY_DIR}/onemath_sycl_blas)
+  else()
+    message(STATUS "Looking for onemath_sycl_blas for generic backend "
+            "- not found locally, fetching from github")
+    include(FetchContent)
+    set(FETCHCONTENT_BASE_DIR "${CMAKE_BINARY_DIR}/deps")
+    FetchContent_Declare(
+      onemath_sycl_blas
+      GIT_REPOSITORY https://github.com/uxlfoundation/generic-sycl-components
+      GIT_TAG        main
+      SOURCE_SUBDIR onemath/sycl/blas
+    )
+    FetchContent_MakeAvailable(onemath_sycl_blas)
+    message(STATUS "Looking for onemath_sycl_blas - downloaded")
+  endif()
+
 endif()
 
 set(SOURCES


### PR DESCRIPTION
Add cmake option `-DONEMATH_SYCL_BLAS_SOURCE_DIR=<path>` to provide a local checkout of the generic SYCL BLAS backend instead of always pulling from github. This facilitates local development of the generic SYCL BLAS code while testing within oneMath.

The search now works as follows (only the second step is new):
1. Try `find_package` to locate precompiled library and headers (as far as I'm aware no FindModule exists for onemath_sycl_blas).
2. If the option `ONEMATH_SYCL_BLAS_SOURCE_DIR` is used, pass the path to `add_subdirectory`.
3. Use FetchContent to check out the main branch from GitHub.

Additionally, do not set `BLAS_ENABLE_COMPLEX=ON` explicitly - this is already the default value.