### PR TITLE
[cmake] update MKLConfig to 2025.1 release and gtest cmake version to 3.13

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -81,13 +81,13 @@ jobs:
     - name: Install compiler
       if: steps.domain_check.outputs.result == 'true'
       run: |
-        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/ac92f2bb-4818-4e53-a432-f8b34d502f23/intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh
-        sudo bash intel-dpcpp-cpp-compiler-2025.0.0.740_offline.sh -s -a -s --action install --eula accept
+        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/cd63be99-88b0-4981-bea1-2034fe17f5cf/intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh
+        sudo bash intel-dpcpp-cpp-compiler-2025.1.0.573_offline.sh -s -a -s --action install --eula accept
     - name: Install Intel oneMKL
       if: steps.domain_check.outputs.result == 'true'
       run: |
-        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/79153e0f-74d7-45af-b8c2-258941adf58a/intel-onemkl-2025.0.0.940_offline.sh
-        sudo bash intel-onemkl-2025.0.0.940_offline.sh -s -a -s --action install --eula accept
+        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/dc93af13-2b3f-40c3-a41b-2bc05a707a80/intel-onemkl-2025.1.0.803_offline.sh
+        sudo bash intel-onemkl-2025.1.0.803_offline.sh -s -a -s --action install --eula accept
     - name: Configure/Build for a domain
       if: steps.domain_check.outputs.result == 'true'
       run: |

--- a/cmake/mkl/MKLConfigVersion.cmake
+++ b/cmake/mkl/MKLConfigVersion.cmake
@@ -17,16 +17,16 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-set(PACKAGE_VERSION "2025.0.0")
+set(PACKAGE_VERSION "2025.1.0")
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()
 
-  if("2025.0.0" MATCHES "^([0-9]+)\\.")
+  if("2025.1.0" MATCHES "^([0-9]+)\\.")
     set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
   else()
-    set(CVF_VERSION_MAJOR "2025.0.0")
+    set(CVF_VERSION_MAJOR "2025.1.0")
   endif()
 
   if(PACKAGE_FIND_VERSION_MAJOR STREQUAL CVF_VERSION_MAJOR)

--- a/deps/googletest/CMakeLists.txt
+++ b/deps/googletest/CMakeLists.txt
@@ -50,7 +50,7 @@ else()
   cmake_policy(SET CMP0048 NEW)
   project(gtest VERSION 1.8.1 LANGUAGES CXX C)
 endif()
-cmake_minimum_required(VERSION 2.6.4)
+cmake_minimum_required(VERSION 3.13)
 
 if (POLICY CMP0063) # Visibility
   cmake_policy(SET CMP0063 NEW)

--- a/deps/googletest/cmake/internal_utils.cmake
+++ b/deps/googletest/cmake/internal_utils.cmake
@@ -242,7 +242,9 @@ function(cxx_executable name dir libs)
 endfunction()
 
 # Sets PYTHONINTERP_FOUND and PYTHON_EXECUTABLE.
+if (CMAKE_VERSION VERSION_LESS 3.27)
 find_package(PythonInterp)
+endif()
 
 # cxx_test_with_flags(name cxx_flags libs srcs...)
 #


### PR DESCRIPTION
# Description

PR updates MKLConfig copy in this repo to the latest available one from Intel oneMKL 2025.1 release and updates oneMKL/Compiler versions to 2025.1 in PR CI workflow.

PR also updates min cmake version for googletest to 3.13 since the latest cmake from CI no longer supports anything < 3.5

# Checklist

## All Submissions

- [x] Do all unit tests pass locally?

Please note, generic BLAS failed because generic-sycl-components project uses too old cmake version. Not related to the changes from this PR