### PR TITLE
[Lapack][MKL-backend] Fix LAPACK specific exceptions

### DIFF
--- a/include/oneapi/math/lapack/exceptions.hpp
+++ b/include/oneapi/math/lapack/exceptions.hpp
@@ -60,7 +60,7 @@ public:
 class batch_error : public oneapi::math::batch_error, public oneapi::math::lapack::exception {
 public:
     batch_error(const std::string& message, std::int64_t num_errors,
-              std::vector<std::int64_t> ids = {}, std::vector<std::exception_ptr> exceptions = {})
+                std::vector<std::int64_t> ids = {}, std::vector<std::exception_ptr> exceptions = {})
             : oneapi::math::batch_error(message),
               oneapi::math::lapack::exception(this, num_errors),
               _ids(ids),
@@ -87,8 +87,8 @@ private:
 class invalid_argument : public oneapi::math::invalid_argument,
                          public oneapi::math::lapack::exception {
 public:
-    invalid_argument(const std::string& message,
-                  std::int64_t arg_position = 0, std::int64_t detail = 0)
+    invalid_argument(const std::string& message, std::int64_t arg_position = 0,
+                     std::int64_t detail = 0)
             : oneapi::math::invalid_argument(message),
               oneapi::math::lapack::exception(this, arg_position, detail) {}
     invalid_argument(const std::string& function, const std::string& info,

--- a/include/oneapi/math/lapack/exceptions.hpp
+++ b/include/oneapi/math/lapack/exceptions.hpp
@@ -48,6 +48,9 @@ private:
 class computation_error : public oneapi::math::computation_error,
                           public oneapi::math::lapack::exception {
 public:
+    computation_error(const std::string& message, std::int64_t code)
+            : oneapi::math::computation_error(message),
+              oneapi::math::lapack::exception(this, code) {}
     computation_error(const std::string& function, const std::string& info, std::int64_t code)
             : oneapi::math::computation_error("LAPACK", function, info),
               oneapi::math::lapack::exception(this, code) {}
@@ -56,6 +59,12 @@ public:
 
 class batch_error : public oneapi::math::batch_error, public oneapi::math::lapack::exception {
 public:
+    batch_error(const std::string& message, std::int64_t num_errors,
+              std::vector<std::int64_t> ids = {}, std::vector<std::exception_ptr> exceptions = {})
+            : oneapi::math::batch_error(message),
+              oneapi::math::lapack::exception(this, num_errors),
+              _ids(ids),
+              _exceptions(exceptions) {}
     batch_error(const std::string& function, const std::string& info, std::int64_t num_errors,
                 std::vector<std::int64_t> ids = {}, std::vector<std::exception_ptr> exceptions = {})
             : oneapi::math::batch_error("LAPACK", function, info),
@@ -78,6 +87,10 @@ private:
 class invalid_argument : public oneapi::math::invalid_argument,
                          public oneapi::math::lapack::exception {
 public:
+    invalid_argument(const std::string& message,
+                  std::int64_t arg_position = 0, std::int64_t detail = 0)
+            : oneapi::math::invalid_argument(message),
+              oneapi::math::lapack::exception(this, arg_position, detail) {}
     invalid_argument(const std::string& function, const std::string& info,
                      std::int64_t arg_position = 0, std::int64_t detail = 0)
             : oneapi::math::invalid_argument("LAPACK", function, info),

--- a/src/include/common_onemkl_conversion.hpp
+++ b/src/include/common_onemkl_conversion.hpp
@@ -28,6 +28,7 @@
 
 #include "oneapi/math/types.hpp"
 #include "oneapi/math/exceptions.hpp"
+#include "oneapi/math/lapack/exceptions.hpp"
 
 namespace oneapi {
 namespace math {
@@ -105,39 +106,44 @@ inline auto get_onemkl_order(oneapi::math::order param) {
     return *reinterpret_cast<oneapi::mkl::order*>(&param);
 }
 
+} // namespace detail
+} // namespace math
+} // namespace oneapi
+
+
 // Rethrow Intel(R) oneMKL exceptions as oneMath exceptions
-#define RETHROW_ONEMKL_EXCEPTIONS(EXPRESSION)              \
-    do {                                                   \
-        try {                                              \
-            EXPRESSION;                                    \
-        }                                                  \
-        catch (const oneapi::mkl::unsupported_device& e) { \
-            throw unsupported_device(e.what());            \
-        }                                                  \
-        catch (const oneapi::mkl::host_bad_alloc& e) {     \
-            throw host_bad_alloc(e.what());                \
-        }                                                  \
-        catch (const oneapi::mkl::device_bad_alloc& e) {   \
-            throw device_bad_alloc(e.what());              \
-        }                                                  \
-        catch (const oneapi::mkl::unimplemented& e) {      \
-            throw unimplemented(e.what());                 \
-        }                                                  \
-        catch (const oneapi::mkl::invalid_argument& e) {   \
-            throw invalid_argument(e.what());              \
-        }                                                  \
-        catch (const oneapi::mkl::uninitialized& e) {      \
-            throw uninitialized(e.what());                 \
-        }                                                  \
-        catch (const oneapi::mkl::computation_error& e) {  \
-            throw computation_error(e.what());             \
-        }                                                  \
-        catch (const oneapi::mkl::batch_error& e) {        \
-            throw batch_error(e.what());                   \
-        }                                                  \
-        catch (const oneapi::mkl::exception& e) {          \
-            throw exception(e.what());                     \
-        }                                                  \
+#define RETHROW_ONEMKL_EXCEPTIONS(EXPRESSION)                  \
+    do {                                                       \
+        try {                                                  \
+            EXPRESSION;                                        \
+        }                                                      \
+        catch (const oneapi::mkl::unsupported_device& e) {     \
+            throw oneapi::math::unsupported_device(e.what());  \
+        }                                                      \
+        catch (const oneapi::mkl::host_bad_alloc& e) {         \
+            throw oneapi::math::host_bad_alloc(e.what());      \
+        }                                                      \
+        catch (const oneapi::mkl::device_bad_alloc& e) {       \
+            throw oneapi::math::device_bad_alloc(e.what());    \
+        }                                                      \
+        catch (const oneapi::mkl::unimplemented& e) {          \
+            throw oneapi::math::unimplemented(e.what());       \
+        }                                                      \
+        catch (const oneapi::mkl::invalid_argument& e) {       \
+            throw oneapi::math::invalid_argument(e.what());    \
+        }                                                      \
+        catch (const oneapi::mkl::uninitialized& e) {          \
+            throw oneapi::math::uninitialized(e.what());       \
+        }                                                      \
+        catch (const oneapi::mkl::computation_error& e) {      \
+            throw oneapi::math::computation_error(e.what());   \
+        }                                                      \
+        catch (const oneapi::mkl::batch_error& e) {            \
+            throw oneapi::math::batch_error(e.what());         \
+        }                                                      \
+        catch (const oneapi::mkl::exception& e) {              \
+            throw oneapi::math::exception(e.what());           \
+        }                                                      \
     } while (0)
 
 #define RETHROW_ONEMKL_EXCEPTIONS_RET(EXPRESSION)     \
@@ -145,8 +151,49 @@ inline auto get_onemkl_order(oneapi::math::order param) {
         RETHROW_ONEMKL_EXCEPTIONS(return EXPRESSION); \
     } while (0)
 
-} // namespace detail
-} // namespace math
-} // namespace oneapi
+
+
+// Rethrow Intel(R) oneMKL LAPCK exceptions as oneMath LAPACK exceptions
+#define RETHROW_ONEMKL_LAPACK_EXCEPTIONS(EXPRESSION)                             \
+    do {                                                                         \
+        try {                                                                    \
+            EXPRESSION;                                                          \
+        }                                                                        \
+        catch (const oneapi::mkl::unsupported_device& e) {                       \
+            throw oneapi::math::unsupported_device(e.what());                    \
+        }                                                                        \
+        catch (const oneapi::mkl::host_bad_alloc& e) {                           \
+            throw oneapi::math::host_bad_alloc(e.what());                        \
+        }                                                                        \
+        catch (const oneapi::mkl::device_bad_alloc& e) {                         \
+            throw oneapi::math::device_bad_alloc(e.what());                      \
+        }                                                                        \
+        catch (const oneapi::mkl::unimplemented& e) {                            \
+            throw oneapi::math::unimplemented(e.what());                         \
+        }                                                                        \
+       catch (const oneapi::mkl::uninitialized& e) {                             \
+            throw oneapi::math::uninitialized(e.what());                         \
+        }                                                                        \
+        catch (const oneapi::mkl::lapack::invalid_argument& e) {                 \
+            throw oneapi::math::lapack::invalid_argument(e.what(), e.info(),     \
+                                                                e.detail());     \
+        }                                                                        \
+        catch (const oneapi::mkl::lapack::computation_error& e) {                \
+            throw oneapi::math::lapack::computation_error(e.what(), e.info());   \
+        }                                                                        \
+        catch (const oneapi::mkl::lapack::batch_error& e) {                      \
+            throw oneapi::math::lapack::batch_error(e.what(), e.info(), e.ids(), \
+                                                                e.exceptions()); \
+        }                                                                        \
+        catch (const oneapi::mkl::exception& e) {                                \
+            throw oneapi::math::exception(e.what());                             \
+        }                                                                        \
+    } while (0)
+
+#define RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(EXPRESSION)     \
+    do {                                                     \
+        RETHROW_ONEMKL_LAPACK_EXCEPTIONS(return EXPRESSION); \
+    } while (0)
+
 
 #endif // _ONEMATH_SRC_INCLUDE_COMMON_ONEMKL_TYPES_CONVERSION_HPP_

--- a/src/include/common_onemkl_conversion.hpp
+++ b/src/include/common_onemkl_conversion.hpp
@@ -110,40 +110,39 @@ inline auto get_onemkl_order(oneapi::math::order param) {
 } // namespace math
 } // namespace oneapi
 
-
 // Rethrow Intel(R) oneMKL exceptions as oneMath exceptions
-#define RETHROW_ONEMKL_EXCEPTIONS(EXPRESSION)                  \
-    do {                                                       \
-        try {                                                  \
-            EXPRESSION;                                        \
-        }                                                      \
-        catch (const oneapi::mkl::unsupported_device& e) {     \
-            throw oneapi::math::unsupported_device(e.what());  \
-        }                                                      \
-        catch (const oneapi::mkl::host_bad_alloc& e) {         \
-            throw oneapi::math::host_bad_alloc(e.what());      \
-        }                                                      \
-        catch (const oneapi::mkl::device_bad_alloc& e) {       \
-            throw oneapi::math::device_bad_alloc(e.what());    \
-        }                                                      \
-        catch (const oneapi::mkl::unimplemented& e) {          \
-            throw oneapi::math::unimplemented(e.what());       \
-        }                                                      \
-        catch (const oneapi::mkl::invalid_argument& e) {       \
-            throw oneapi::math::invalid_argument(e.what());    \
-        }                                                      \
-        catch (const oneapi::mkl::uninitialized& e) {          \
-            throw oneapi::math::uninitialized(e.what());       \
-        }                                                      \
-        catch (const oneapi::mkl::computation_error& e) {      \
-            throw oneapi::math::computation_error(e.what());   \
-        }                                                      \
-        catch (const oneapi::mkl::batch_error& e) {            \
-            throw oneapi::math::batch_error(e.what());         \
-        }                                                      \
-        catch (const oneapi::mkl::exception& e) {              \
-            throw oneapi::math::exception(e.what());           \
-        }                                                      \
+#define RETHROW_ONEMKL_EXCEPTIONS(EXPRESSION)                 \
+    do {                                                      \
+        try {                                                 \
+            EXPRESSION;                                       \
+        }                                                     \
+        catch (const oneapi::mkl::unsupported_device& e) {    \
+            throw oneapi::math::unsupported_device(e.what()); \
+        }                                                     \
+        catch (const oneapi::mkl::host_bad_alloc& e) {        \
+            throw oneapi::math::host_bad_alloc(e.what());     \
+        }                                                     \
+        catch (const oneapi::mkl::device_bad_alloc& e) {      \
+            throw oneapi::math::device_bad_alloc(e.what());   \
+        }                                                     \
+        catch (const oneapi::mkl::unimplemented& e) {         \
+            throw oneapi::math::unimplemented(e.what());      \
+        }                                                     \
+        catch (const oneapi::mkl::invalid_argument& e) {      \
+            throw oneapi::math::invalid_argument(e.what());   \
+        }                                                     \
+        catch (const oneapi::mkl::uninitialized& e) {         \
+            throw oneapi::math::uninitialized(e.what());      \
+        }                                                     \
+        catch (const oneapi::mkl::computation_error& e) {     \
+            throw oneapi::math::computation_error(e.what());  \
+        }                                                     \
+        catch (const oneapi::mkl::batch_error& e) {           \
+            throw oneapi::math::batch_error(e.what());        \
+        }                                                     \
+        catch (const oneapi::mkl::exception& e) {             \
+            throw oneapi::math::exception(e.what());          \
+        }                                                     \
     } while (0)
 
 #define RETHROW_ONEMKL_EXCEPTIONS_RET(EXPRESSION)     \
@@ -151,49 +150,44 @@ inline auto get_onemkl_order(oneapi::math::order param) {
         RETHROW_ONEMKL_EXCEPTIONS(return EXPRESSION); \
     } while (0)
 
-
-
 // Rethrow Intel(R) oneMKL LAPCK exceptions as oneMath LAPACK exceptions
-#define RETHROW_ONEMKL_LAPACK_EXCEPTIONS(EXPRESSION)                             \
-    do {                                                                         \
-        try {                                                                    \
-            EXPRESSION;                                                          \
-        }                                                                        \
-        catch (const oneapi::mkl::unsupported_device& e) {                       \
-            throw oneapi::math::unsupported_device(e.what());                    \
-        }                                                                        \
-        catch (const oneapi::mkl::host_bad_alloc& e) {                           \
-            throw oneapi::math::host_bad_alloc(e.what());                        \
-        }                                                                        \
-        catch (const oneapi::mkl::device_bad_alloc& e) {                         \
-            throw oneapi::math::device_bad_alloc(e.what());                      \
-        }                                                                        \
-        catch (const oneapi::mkl::unimplemented& e) {                            \
-            throw oneapi::math::unimplemented(e.what());                         \
-        }                                                                        \
-       catch (const oneapi::mkl::uninitialized& e) {                             \
-            throw oneapi::math::uninitialized(e.what());                         \
-        }                                                                        \
-        catch (const oneapi::mkl::lapack::invalid_argument& e) {                 \
-            throw oneapi::math::lapack::invalid_argument(e.what(), e.info(),     \
-                                                                e.detail());     \
-        }                                                                        \
-        catch (const oneapi::mkl::lapack::computation_error& e) {                \
-            throw oneapi::math::lapack::computation_error(e.what(), e.info());   \
-        }                                                                        \
-        catch (const oneapi::mkl::lapack::batch_error& e) {                      \
-            throw oneapi::math::lapack::batch_error(e.what(), e.info(), e.ids(), \
-                                                                e.exceptions()); \
-        }                                                                        \
-        catch (const oneapi::mkl::exception& e) {                                \
-            throw oneapi::math::exception(e.what());                             \
-        }                                                                        \
+#define RETHROW_ONEMKL_LAPACK_EXCEPTIONS(EXPRESSION)                                              \
+    do {                                                                                          \
+        try {                                                                                     \
+            EXPRESSION;                                                                           \
+        }                                                                                         \
+        catch (const oneapi::mkl::unsupported_device& e) {                                        \
+            throw oneapi::math::unsupported_device(e.what());                                     \
+        }                                                                                         \
+        catch (const oneapi::mkl::host_bad_alloc& e) {                                            \
+            throw oneapi::math::host_bad_alloc(e.what());                                         \
+        }                                                                                         \
+        catch (const oneapi::mkl::device_bad_alloc& e) {                                          \
+            throw oneapi::math::device_bad_alloc(e.what());                                       \
+        }                                                                                         \
+        catch (const oneapi::mkl::unimplemented& e) {                                             \
+            throw oneapi::math::unimplemented(e.what());                                          \
+        }                                                                                         \
+        catch (const oneapi::mkl::uninitialized& e) {                                             \
+            throw oneapi::math::uninitialized(e.what());                                          \
+        }                                                                                         \
+        catch (const oneapi::mkl::lapack::invalid_argument& e) {                                  \
+            throw oneapi::math::lapack::invalid_argument(e.what(), e.info(), e.detail());         \
+        }                                                                                         \
+        catch (const oneapi::mkl::lapack::computation_error& e) {                                 \
+            throw oneapi::math::lapack::computation_error(e.what(), e.info());                    \
+        }                                                                                         \
+        catch (const oneapi::mkl::lapack::batch_error& e) {                                       \
+            throw oneapi::math::lapack::batch_error(e.what(), e.info(), e.ids(), e.exceptions()); \
+        }                                                                                         \
+        catch (const oneapi::mkl::exception& e) {                                                 \
+            throw oneapi::math::exception(e.what());                                              \
+        }                                                                                         \
     } while (0)
 
 #define RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(EXPRESSION)     \
     do {                                                     \
         RETHROW_ONEMKL_LAPACK_EXCEPTIONS(return EXPRESSION); \
     } while (0)
-
 
 #endif // _ONEMATH_SRC_INCLUDE_COMMON_ONEMKL_TYPES_CONVERSION_HPP_

--- a/src/lapack/backends/mkl_common/mkl_lapack.cxx
+++ b/src/lapack/backends/mkl_common/mkl_lapack.cxx
@@ -21,30 +21,30 @@ void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<std:
            std::int64_t lda, sycl::buffer<float>& d, sycl::buffer<float>& e,
            sycl::buffer<std::complex<float>>& tauq, sycl::buffer<std::complex<float>>& taup,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
-                                                           scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(
+        queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size));
 }
 void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& d, sycl::buffer<double>& e,
            sycl::buffer<double>& tauq, sycl::buffer<double>& taup, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
-                                                           scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(
+        queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size));
 }
 void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& d, sycl::buffer<float>& e,
            sycl::buffer<float>& tauq, sycl::buffer<float>& taup, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
-                                                           scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(
+        queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size));
 }
 void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda, sycl::buffer<double>& d,
            sycl::buffer<double>& e, sycl::buffer<std::complex<double>>& tauq,
            sycl::buffer<std::complex<double>>& taup, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
-                                                           scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(
+        queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size));
 }
 void gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& tau, sycl::buffer<float>& scratchpad,
@@ -217,16 +217,16 @@ void gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::jobsvd j
 void heevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda, sycl::buffer<float>& w,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::heevd(queue, detail::get_onemkl_job(jobz),
-                                                           detail::get_onemkl_uplo(uplo), n, a, lda,
-                                                           w, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::heevd(
+        queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
+        scratchpad, scratchpad_size));
 }
 void heevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda, sycl::buffer<double>& w,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::heevd(queue, detail::get_onemkl_job(jobz),
-                                                           detail::get_onemkl_uplo(uplo), n, a, lda,
-                                                           w, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::heevd(
+        queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
+        scratchpad, scratchpad_size));
 }
 void hegvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz, oneapi::math::uplo uplo,
            std::int64_t n, sycl::buffer<std::complex<float>>& a, std::int64_t lda,
@@ -274,16 +274,16 @@ void hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
 void orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
            std::int64_t k, sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& tau,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec),
-                                                           m, n, k, a, lda, tau, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
+                                     scratchpad, scratchpad_size));
 }
 void orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
            std::int64_t k, sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& tau,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec),
-                                                           m, n, k, a, lda, tau, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
+                                     scratchpad, scratchpad_size));
 }
 void orgqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& tau,
@@ -361,91 +361,91 @@ void ormqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           a, lda, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(
+        queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad, scratchpad_size));
 }
 void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& b, std::int64_t ldb,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           nrhs, a, lda, b, ldb, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size));
 }
 void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& b, std::int64_t ldb,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           nrhs, a, lda, b, ldb, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size));
 }
 void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           nrhs, a, lda, b, ldb, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size));
 }
 void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
-                                                           nrhs, a, lda, b, ldb, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size));
 }
 void syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& w,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::syevd(queue, detail::get_onemkl_job(jobz),
-                                                           detail::get_onemkl_uplo(uplo), n, a, lda,
-                                                           w, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::syevd(
+        queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
+        scratchpad, scratchpad_size));
 }
 void syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& w,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::syevd(queue, detail::get_onemkl_job(jobz),
-                                                           detail::get_onemkl_uplo(uplo), n, a, lda,
-                                                           w, scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::syevd(
+        queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
+        scratchpad, scratchpad_size));
 }
 void sygvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz, oneapi::math::uplo uplo,
            std::int64_t n, sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& b,
@@ -540,17 +540,17 @@ void ungbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::
            std::int64_t k, sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& tau, sycl::buffer<std::complex<float>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec),
-                                                           m, n, k, a, lda, tau, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
+                                     scratchpad, scratchpad_size));
 }
 void ungbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
            std::int64_t k, sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec),
-                                                           m, n, k, a, lda, tau, scratchpad,
-                                                           scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
+                                     scratchpad, scratchpad_size));
 }
 void ungqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
@@ -667,50 +667,50 @@ sycl::event gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, std::compl
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a, std::int64_t lda,
                   float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, double* a, std::int64_t lda,
                   double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<float>* a,
                   std::int64_t lda, std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<double>* a,
                   std::int64_t lda, std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<float>* a,
                   std::int64_t lda, std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, double* a, std::int64_t lda,
                   double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a, std::int64_t lda,
                   float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<double>* a,
                   std::int64_t lda, std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(
+        queue, m, n, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<float>* a,
                   std::int64_t lda, std::int64_t* ipiv, std::complex<float>* scratchpad,
@@ -739,26 +739,26 @@ sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::compl
 sycl::event getri(sycl::queue& queue, std::int64_t n, std::complex<float>* a, std::int64_t lda,
                   std::int64_t* ipiv, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(
+        queue, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, double* a, std::int64_t lda,
                   std::int64_t* ipiv, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(
+        queue, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, float* a, std::int64_t lda,
                   std::int64_t* ipiv, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(
+        queue, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, std::complex<double>* a, std::int64_t lda,
                   std::int64_t* ipiv, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(
+        queue, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<float>* a, std::int64_t lda, std::int64_t* ipiv,
@@ -864,33 +864,33 @@ sycl::event hetrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, float* d, float* e,
                   std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, d, e, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event hetrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, double* d, double* e,
                   std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, d, e, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, float* a, std::int64_t lda, float* tau, float* scratchpad,
@@ -921,16 +921,16 @@ sycl::event orgqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64
 sycl::event orgtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event orgtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event ormtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::uplo uplo,
                   oneapi::math::transpose trans, std::int64_t m, std::int64_t n, float* a,
@@ -985,88 +985,88 @@ sycl::event ormqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n, a, lda, scratchpad,
+                                     scratchpad_size, dependencies));
 }
 sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   float* a, std::int64_t lda, float* b, std::int64_t ldb, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, nrhs, a, lda, b, ldb, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   double* a, std::int64_t lda, double* b, std::int64_t ldb, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, nrhs, a, lda, b, ldb, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* b,
                   std::int64_t ldb, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, nrhs, a, lda, b, ldb, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* b,
                   std::int64_t ldb, std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, nrhs, a, lda, b, ldb, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo,
                   std::int64_t n, double* a, std::int64_t lda, double* w, double* scratchpad,
@@ -1101,46 +1101,46 @@ sycl::event sygvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz
 sycl::event sytrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* d, double* e, double* tau, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, d, e, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event sytrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* d, float* e, float* tau, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, d, e, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, std::int64_t* ipiv, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, std::int64_t* ipiv, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, ipiv, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::transpose trans,
                   oneapi::math::diag diag, std::int64_t n, std::int64_t nrhs,
@@ -1214,17 +1214,17 @@ sycl::event ungtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* tau,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event ungtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* tau,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo),
-                                                               n, a, lda, tau, scratchpad,
-                                                               scratchpad_size, dependencies));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau,
+                                     scratchpad, scratchpad_size, dependencies));
 }
 sycl::event unmrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose trans,
                   std::int64_t m, std::int64_t n, std::int64_t k, std::complex<float>* a,
@@ -1413,17 +1413,17 @@ void orgqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_
                  sycl::buffer<float>& a, std::int64_t lda, std::int64_t stride_a,
                  sycl::buffer<float>& tau, std::int64_t stride_tau, std::int64_t batch_size,
                  sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a,
-                                                                 tau, stride_tau, batch_size,
-                                                                 scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
+                                           batch_size, scratchpad, scratchpad_size));
 }
 void orgqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
                  sycl::buffer<double>& a, std::int64_t lda, std::int64_t stride_a,
                  sycl::buffer<double>& tau, std::int64_t stride_tau, std::int64_t batch_size,
                  sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a,
-                                                                 tau, stride_tau, batch_size,
-                                                                 scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
+                                           batch_size, scratchpad, scratchpad_size));
 }
 void potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                  sycl::buffer<float>& a, std::int64_t lda, std::int64_t stride_a,
@@ -1498,18 +1498,18 @@ void ungqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_
                  sycl::buffer<std::complex<float>>& tau, std::int64_t stride_tau,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a,
-                                                                 tau, stride_tau, batch_size,
-                                                                 scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
+                                           batch_size, scratchpad, scratchpad_size));
 }
 void ungqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
                  sycl::buffer<std::complex<double>>& a, std::int64_t lda, std::int64_t stride_a,
                  sycl::buffer<std::complex<double>>& tau, std::int64_t stride_tau,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a,
-                                                                 tau, stride_tau, batch_size,
-                                                                 scratchpad, scratchpad_size));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
+        ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
+                                           batch_size, scratchpad, scratchpad_size));
 }
 sycl::event geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a,
                         std::int64_t lda, std::int64_t stride_a, float* tau,
@@ -2110,9 +2110,10 @@ std::int64_t gesvd_scratchpad_size<std::complex<float>>(sycl::queue& queue,
                                                         oneapi::math::jobsvd jobvt, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda,
                                                         std::int64_t ldu, std::int64_t ldvt) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, lda, ldu,
-        ldvt));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, lda,
+            ldu, ldvt));
 }
 template <>
 std::int64_t gesvd_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2190,8 +2191,9 @@ std::int64_t getrs_scratchpad_size<std::complex<float>>(sycl::queue& queue,
                                                         oneapi::math::transpose trans,
                                                         std::int64_t n, std::int64_t nrhs,
                                                         std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::getrs_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t getrs_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2206,8 +2208,9 @@ template <>
 std::int64_t heevd_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::job jobz,
                                                         oneapi::math::uplo uplo, std::int64_t n,
                                                         std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t heevd_scratchpad_size<std::complex<double>>(sycl::queue& queue, oneapi::math::job jobz,
@@ -2222,8 +2225,10 @@ std::int64_t hegvd_scratchpad_size<std::complex<float>>(sycl::queue& queue, std:
                                                         oneapi::math::job jobz,
                                                         oneapi::math::uplo uplo, std::int64_t n,
                                                         std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<float>>(
-        queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda, ldb));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<float>>(
+            queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda,
+            ldb));
 }
 template <>
 std::int64_t hegvd_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t itype,
@@ -2238,8 +2243,9 @@ std::int64_t hegvd_scratchpad_size<std::complex<double>>(sycl::queue& queue, std
 template <>
 std::int64_t hetrd_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hetrd_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t hetrd_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2252,8 +2258,9 @@ std::int64_t hetrd_scratchpad_size<std::complex<double>>(sycl::queue& queue,
 template <>
 std::int64_t hetrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::hetrf_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t hetrf_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2370,8 +2377,9 @@ std::int64_t potrf_scratchpad_size<double>(sycl::queue& queue, oneapi::math::upl
 template <>
 std::int64_t potrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrf_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potrf_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2399,8 +2407,9 @@ template <>
 std::int64_t potrs_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t nrhs,
                                                         std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potrs_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t potrs_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2426,8 +2435,9 @@ std::int64_t potri_scratchpad_size<double>(sycl::queue& queue, oneapi::math::upl
 template <>
 std::int64_t potri_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::potri_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potri_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2452,8 +2462,9 @@ std::int64_t sytrf_scratchpad_size<double>(sycl::queue& queue, oneapi::math::upl
 template <>
 std::int64_t sytrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::sytrf_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sytrf_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2527,9 +2538,10 @@ std::int64_t trtrs_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         oneapi::math::diag diag, std::int64_t n,
                                                         std::int64_t nrhs, std::int64_t lda,
                                                         std::int64_t ldb) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
-        detail::get_onemkl_diag(diag), n, nrhs, lda, ldb));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::trtrs_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
+            detail::get_onemkl_diag(diag), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t trtrs_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2548,8 +2560,9 @@ std::int64_t ungbr_scratchpad_size<std::complex<float>>(sycl::queue& queue,
                                                         oneapi::math::generate vect, std::int64_t m,
                                                         std::int64_t n, std::int64_t k,
                                                         std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_generate(vect), m, n, k, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_generate(vect), m, n, k, lda));
 }
 template <>
 std::int64_t ungbr_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2577,8 +2590,9 @@ std::int64_t ungqr_scratchpad_size<std::complex<double>>(sycl::queue& queue, std
 template <>
 std::int64_t ungtr_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_uplo(uplo), n, lda));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::ungtr_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t ungtr_scratchpad_size<std::complex<double>>(sycl::queue& queue,
@@ -2594,9 +2608,10 @@ std::int64_t unmrq_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         std::int64_t m, std::int64_t n,
                                                         std::int64_t k, std::int64_t lda,
                                                         std::int64_t ldc) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
-        ldc));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::unmrq_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
+            ldc));
 }
 template <>
 std::int64_t unmrq_scratchpad_size<std::complex<double>>(
@@ -2613,9 +2628,10 @@ std::int64_t unmqr_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         std::int64_t m, std::int64_t n,
                                                         std::int64_t k, std::int64_t lda,
                                                         std::int64_t ldc) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
-        ldc));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
+            ldc));
 }
 template <>
 std::int64_t unmqr_scratchpad_size<std::complex<double>>(
@@ -2632,9 +2648,10 @@ std::int64_t unmtr_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         oneapi::math::transpose trans,
                                                         std::int64_t m, std::int64_t n,
                                                         std::int64_t lda, std::int64_t ldc) {
-    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<float>>(
-        queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
-        detail::get_onemkl_transpose(trans), m, n, lda, ldc));
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
+        ::oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<float>>(
+            queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
+            detail::get_onemkl_transpose(trans), m, n, lda, ldc));
 }
 template <>
 std::int64_t unmtr_scratchpad_size<std::complex<double>>(sycl::queue& queue,

--- a/src/lapack/backends/mkl_common/mkl_lapack.cxx
+++ b/src/lapack/backends/mkl_common/mkl_lapack.cxx
@@ -21,21 +21,21 @@ void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<std:
            std::int64_t lda, sycl::buffer<float>& d, sycl::buffer<float>& e,
            sycl::buffer<std::complex<float>>& tauq, sycl::buffer<std::complex<float>>& taup,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
                                                            scratchpad, scratchpad_size));
 }
 void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& d, sycl::buffer<double>& e,
            sycl::buffer<double>& tauq, sycl::buffer<double>& taup, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
                                                            scratchpad, scratchpad_size));
 }
 void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& d, sycl::buffer<float>& e,
            sycl::buffer<float>& tauq, sycl::buffer<float>& taup, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
                                                            scratchpad, scratchpad_size));
 }
 void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n,
@@ -43,113 +43,113 @@ void gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<double>& e, sycl::buffer<std::complex<double>>& tauq,
            sycl::buffer<std::complex<double>>& taup, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gebrd(queue, m, n, a, lda, d, e, tauq, taup,
                                                            scratchpad, scratchpad_size));
 }
 void gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& tau, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& tau, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<std::complex<float>>& a,
            std::int64_t lda, sycl::buffer<std::complex<float>>& tau,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<std::complex<float>>& a,
            std::int64_t lda, sycl::buffer<std::complex<float>>& tau,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& tau, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& tau, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<std::complex<float>>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getrf(sycl::queue& queue, std::int64_t m, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::int64_t>& ipiv, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrf(queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<double>& a, std::int64_t lda,
            sycl::buffer<std::int64_t>& ipiv, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<float>& a, std::int64_t lda,
            sycl::buffer<std::int64_t>& ipiv, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getri(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<float>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size));
 }
@@ -157,7 +157,7 @@ void getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n, st
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<double>& b, std::int64_t ldb, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size));
 }
@@ -165,7 +165,7 @@ void getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n, st
            sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<float>& b, std::int64_t ldb, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size));
 }
@@ -174,7 +174,7 @@ void getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n, st
            sycl::buffer<std::int64_t>& ipiv, sycl::buffer<std::complex<double>>& b,
            std::int64_t ldb, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size));
 }
@@ -183,7 +183,7 @@ void gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::jobsvd j
            sycl::buffer<double>& s, sycl::buffer<double>& u, std::int64_t ldu,
            sycl::buffer<double>& vt, std::int64_t ldvt, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size));
 }
@@ -192,7 +192,7 @@ void gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::jobsvd j
            sycl::buffer<float>& s, sycl::buffer<float>& u, std::int64_t ldu,
            sycl::buffer<float>& vt, std::int64_t ldvt, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size));
 }
@@ -201,7 +201,7 @@ void gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::jobsvd j
            sycl::buffer<float>& s, sycl::buffer<std::complex<float>>& u, std::int64_t ldu,
            sycl::buffer<std::complex<float>>& vt, std::int64_t ldvt,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size));
 }
@@ -210,21 +210,21 @@ void gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::jobsvd j
            sycl::buffer<double>& s, sycl::buffer<std::complex<double>>& u, std::int64_t ldu,
            sycl::buffer<std::complex<double>>& vt, std::int64_t ldvt,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size));
 }
 void heevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda, sycl::buffer<float>& w,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::heevd(queue, detail::get_onemkl_job(jobz),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::heevd(queue, detail::get_onemkl_job(jobz),
                                                            detail::get_onemkl_uplo(uplo), n, a, lda,
                                                            w, scratchpad, scratchpad_size));
 }
 void heevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda, sycl::buffer<double>& w,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::heevd(queue, detail::get_onemkl_job(jobz),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::heevd(queue, detail::get_onemkl_job(jobz),
                                                            detail::get_onemkl_uplo(uplo), n, a, lda,
                                                            w, scratchpad, scratchpad_size));
 }
@@ -232,7 +232,7 @@ void hegvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz, oneap
            std::int64_t n, sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& b, std::int64_t ldb, sycl::buffer<float>& w,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::hegvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::hegvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size));
 }
@@ -240,7 +240,7 @@ void hegvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz, oneap
            std::int64_t n, sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& b, std::int64_t ldb, sycl::buffer<double>& w,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::hegvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::hegvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size));
 }
@@ -248,72 +248,72 @@ void hetrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda, sycl::buffer<float>& d,
            sycl::buffer<float>& e, sycl::buffer<std::complex<float>>& tau,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::hetrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::hetrd(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau, scratchpad, scratchpad_size));
 }
 void hetrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda, sycl::buffer<double>& d,
            sycl::buffer<double>& e, sycl::buffer<std::complex<double>>& tau,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::hetrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::hetrd(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau, scratchpad, scratchpad_size));
 }
 void hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::hetrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::hetrf(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::int64_t>& ipiv, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::hetrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::hetrf(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
            std::int64_t k, sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& tau,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec),
                                                            m, n, k, a, lda, tau, scratchpad,
                                                            scratchpad_size));
 }
 void orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
            std::int64_t k, sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& tau,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec),
                                                            m, n, k, a, lda, tau, scratchpad,
                                                            scratchpad_size));
 }
 void orgqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& tau,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::orgqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size));
 }
 void orgqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
            sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& tau,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::orgqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size));
 }
 void orgtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& tau, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::orgtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgtr(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void orgtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& tau, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::orgtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgtr(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void ormtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::uplo uplo,
            oneapi::math::transpose trans, std::int64_t m, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& tau, sycl::buffer<float>& c, std::int64_t ldc,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ormtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ormtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad,
         scratchpad_size));
@@ -322,7 +322,7 @@ void ormtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::uplo uplo,
            oneapi::math::transpose trans, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& tau, sycl::buffer<double>& c, std::int64_t ldc,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ormtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ormtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad,
         scratchpad_size));
@@ -331,7 +331,7 @@ void ormrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t m, std::int64_t n, std::int64_t k, sycl::buffer<float>& a, std::int64_t lda,
            sycl::buffer<float>& tau, sycl::buffer<float>& c, std::int64_t ldc,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ormrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ormrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -339,7 +339,7 @@ void ormrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t m, std::int64_t n, std::int64_t k, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& tau, sycl::buffer<double>& c, std::int64_t ldc,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ormrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ormrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -347,7 +347,7 @@ void ormqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t m, std::int64_t n, std::int64_t k, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& tau, sycl::buffer<double>& c, std::int64_t ldc,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ormqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ormqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -355,65 +355,65 @@ void ormqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t m, std::int64_t n, std::int64_t k, sycl::buffer<float>& a, std::int64_t lda,
            sycl::buffer<float>& tau, sycl::buffer<float>& c, std::int64_t ldc,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ormqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ormqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo), n,
                                                            a, lda, scratchpad, scratchpad_size));
 }
 void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& b, std::int64_t ldb,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
                                                            nrhs, a, lda, b, ldb, scratchpad,
                                                            scratchpad_size));
 }
 void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& b, std::int64_t ldb,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
                                                            nrhs, a, lda, b, ldb, scratchpad,
                                                            scratchpad_size));
 }
@@ -421,7 +421,7 @@ void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
                                                            nrhs, a, lda, b, ldb, scratchpad,
                                                            scratchpad_size));
 }
@@ -429,21 +429,21 @@ void potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo), n,
                                                            nrhs, a, lda, b, ldb, scratchpad,
                                                            scratchpad_size));
 }
 void syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& w,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::syevd(queue, detail::get_onemkl_job(jobz),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::syevd(queue, detail::get_onemkl_job(jobz),
                                                            detail::get_onemkl_uplo(uplo), n, a, lda,
                                                            w, scratchpad, scratchpad_size));
 }
 void syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& w,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::syevd(queue, detail::get_onemkl_job(jobz),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::syevd(queue, detail::get_onemkl_job(jobz),
                                                            detail::get_onemkl_uplo(uplo), n, a, lda,
                                                            w, scratchpad, scratchpad_size));
 }
@@ -451,7 +451,7 @@ void sygvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz, oneap
            std::int64_t n, sycl::buffer<double>& a, std::int64_t lda, sycl::buffer<double>& b,
            std::int64_t ldb, sycl::buffer<double>& w, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sygvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sygvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size));
 }
@@ -459,7 +459,7 @@ void sygvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz, oneap
            std::int64_t n, sycl::buffer<float>& a, std::int64_t lda, sycl::buffer<float>& b,
            std::int64_t ldb, sycl::buffer<float>& w, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sygvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sygvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size));
 }
@@ -467,39 +467,39 @@ void sytrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::bu
            std::int64_t lda, sycl::buffer<double>& d, sycl::buffer<double>& e,
            sycl::buffer<double>& tau, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sytrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sytrd(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau, scratchpad, scratchpad_size));
 }
 void sytrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& d, sycl::buffer<float>& e,
            sycl::buffer<float>& tau, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sytrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sytrd(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, d, e, tau, scratchpad, scratchpad_size));
 }
 void sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv, sycl::buffer<float>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<std::int64_t>& ipiv, sycl::buffer<double>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda, sycl::buffer<std::int64_t>& ipiv,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::int64_t>& ipiv, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::sytrf(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, ipiv, scratchpad, scratchpad_size));
 }
 void trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::transpose trans,
@@ -507,7 +507,7 @@ void trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::transpose 
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size));
 }
@@ -515,7 +515,7 @@ void trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::transpose 
            oneapi::math::diag diag, std::int64_t n, std::int64_t nrhs, sycl::buffer<double>& a,
            std::int64_t lda, sycl::buffer<double>& b, std::int64_t ldb,
            sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size));
 }
@@ -523,7 +523,7 @@ void trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::transpose 
            oneapi::math::diag diag, std::int64_t n, std::int64_t nrhs, sycl::buffer<float>& a,
            std::int64_t lda, sycl::buffer<float>& b, std::int64_t ldb,
            sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size));
 }
@@ -532,7 +532,7 @@ void trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::transpose 
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& b, std::int64_t ldb,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size));
 }
@@ -540,7 +540,7 @@ void ungbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::
            std::int64_t k, sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& tau, sycl::buffer<std::complex<float>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec),
                                                            m, n, k, a, lda, tau, scratchpad,
                                                            scratchpad_size));
 }
@@ -548,7 +548,7 @@ void ungbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::
            std::int64_t k, sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec),
                                                            m, n, k, a, lda, tau, scratchpad,
                                                            scratchpad_size));
 }
@@ -556,28 +556,28 @@ void ungqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& tau, sycl::buffer<std::complex<float>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::ungqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size));
 }
 void ungqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::ungqr(queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size));
 }
 void ungtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<float>>& a, std::int64_t lda,
            sycl::buffer<std::complex<float>>& tau, sycl::buffer<std::complex<float>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ungtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungtr(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void ungtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
            sycl::buffer<std::complex<double>>& a, std::int64_t lda,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ungtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungtr(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, tau, scratchpad, scratchpad_size));
 }
 void unmrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose trans,
@@ -585,7 +585,7 @@ void unmrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t lda, sycl::buffer<std::complex<float>>& tau,
            sycl::buffer<std::complex<float>>& c, std::int64_t ldc,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::unmrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::unmrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -594,7 +594,7 @@ void unmrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t lda, sycl::buffer<std::complex<double>>& tau,
            sycl::buffer<std::complex<double>>& c, std::int64_t ldc,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::unmrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::unmrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -603,7 +603,7 @@ void unmqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t lda, sycl::buffer<std::complex<float>>& tau,
            sycl::buffer<std::complex<float>>& c, std::int64_t ldc,
            sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::unmqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::unmqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -612,7 +612,7 @@ void unmqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose 
            std::int64_t lda, sycl::buffer<std::complex<double>>& tau,
            sycl::buffer<std::complex<double>>& c, std::int64_t ldc,
            sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::unmqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::unmqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size));
 }
@@ -622,7 +622,7 @@ void unmtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::uplo uplo,
            sycl::buffer<std::complex<float>>& tau, sycl::buffer<std::complex<float>>& c,
            std::int64_t ldc, sycl::buffer<std::complex<float>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::unmtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::unmtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad,
         scratchpad_size));
@@ -633,7 +633,7 @@ void unmtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::uplo uplo,
            sycl::buffer<std::complex<double>>& tau, sycl::buffer<std::complex<double>>& c,
            std::int64_t ldc, sycl::buffer<std::complex<double>>& scratchpad,
            std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::unmtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::unmtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad,
         scratchpad_size));
@@ -642,129 +642,129 @@ sycl::event gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, std::compl
                   std::int64_t lda, float* d, float* e, std::complex<float>* tauq,
                   std::complex<float>* taup, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
         queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, double* a, std::int64_t lda,
                   double* d, double* e, double* tauq, double* taup, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
         queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a, std::int64_t lda,
                   float* d, float* e, float* tauq, float* taup, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
         queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gebrd(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<double>* a,
                   std::int64_t lda, double* d, double* e, std::complex<double>* tauq,
                   std::complex<double>* taup, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gebrd(
         queue, m, n, a, lda, d, e, tauq, taup, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a, std::int64_t lda,
                   float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, double* a, std::int64_t lda,
                   double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<float>* a,
                   std::int64_t lda, std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event gerqf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<double>* a,
                   std::int64_t lda, std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gerqf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<float>* a,
                   std::int64_t lda, std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, double* a, std::int64_t lda,
                   double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a, std::int64_t lda,
                   float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event geqrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<double>* a,
                   std::int64_t lda, std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf(queue, m, n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<float>* a,
                   std::int64_t lda, std::int64_t* ipiv, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
         queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, double* a, std::int64_t lda,
                   std::int64_t* ipiv, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
         queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, float* a, std::int64_t lda,
                   std::int64_t* ipiv, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
         queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getrf(sycl::queue& queue, std::int64_t m, std::int64_t n, std::complex<double>* a,
                   std::int64_t lda, std::int64_t* ipiv, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf(
         queue, m, n, a, lda, ipiv, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, std::complex<float>* a, std::int64_t lda,
                   std::int64_t* ipiv, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, double* a, std::int64_t lda,
                   std::int64_t* ipiv, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, float* a, std::int64_t lda,
                   std::int64_t* ipiv, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event getri(sycl::queue& queue, std::int64_t n, std::complex<double>* a, std::int64_t lda,
                   std::int64_t* ipiv, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri(queue, n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,
                   std::int64_t nrhs, std::complex<float>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<float>* b, std::int64_t ldb, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size, dependencies));
 }
@@ -772,7 +772,7 @@ sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_
                   std::int64_t nrhs, double* a, std::int64_t lda, std::int64_t* ipiv, double* b,
                   std::int64_t ldb, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size, dependencies));
 }
@@ -780,7 +780,7 @@ sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_
                   std::int64_t nrhs, float* a, std::int64_t lda, std::int64_t* ipiv, float* b,
                   std::int64_t ldb, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size, dependencies));
 }
@@ -788,7 +788,7 @@ sycl::event getrs(sycl::queue& queue, oneapi::math::transpose trans, std::int64_
                   std::int64_t nrhs, std::complex<double>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<double>* b, std::int64_t ldb, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs(queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda,
                                      ipiv, b, ldb, scratchpad, scratchpad_size, dependencies));
 }
@@ -796,7 +796,7 @@ sycl::event gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::j
                   std::int64_t m, std::int64_t n, double* a, std::int64_t lda, double* s, double* u,
                   std::int64_t ldu, double* vt, std::int64_t ldvt, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size, dependencies));
 }
@@ -804,7 +804,7 @@ sycl::event gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::j
                   std::int64_t m, std::int64_t n, float* a, std::int64_t lda, float* s, float* u,
                   std::int64_t ldu, float* vt, std::int64_t ldvt, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size, dependencies));
 }
@@ -813,7 +813,7 @@ sycl::event gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::j
                   float* s, std::complex<float>* u, std::int64_t ldu, std::complex<float>* vt,
                   std::int64_t ldvt, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size, dependencies));
 }
@@ -822,7 +822,7 @@ sycl::event gesvd(sycl::queue& queue, oneapi::math::jobsvd jobu, oneapi::math::j
                   double* s, std::complex<double>* u, std::int64_t ldu, std::complex<double>* vt,
                   std::int64_t ldvt, std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, a, lda, s,
         u, ldu, vt, ldvt, scratchpad, scratchpad_size, dependencies));
 }
@@ -830,7 +830,7 @@ sycl::event heevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo
                   std::int64_t n, std::complex<float>* a, std::int64_t lda, float* w,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -838,7 +838,7 @@ sycl::event heevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo
                   std::int64_t n, std::complex<double>* a, std::int64_t lda, double* w,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -847,7 +847,7 @@ sycl::event hegvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz
                   std::complex<float>* b, std::int64_t ldb, float* w,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size, dependencies));
 }
@@ -856,7 +856,7 @@ sycl::event hegvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz
                   std::int64_t lda, std::complex<double>* b, std::int64_t ldb, double* w,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size, dependencies));
 }
@@ -864,7 +864,7 @@ sycl::event hetrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, float* d, float* e,
                   std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, d, e, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -872,7 +872,7 @@ sycl::event hetrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, double* d, double* e,
                   std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, d, e, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -880,7 +880,7 @@ sycl::event hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -888,47 +888,47 @@ sycl::event hetrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, float* a, std::int64_t lda, float* tau, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
                                      scratchpad, scratchpad_size, dependencies));
 }
 sycl::event orgbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m, std::int64_t n,
                   std::int64_t k, double* a, std::int64_t lda, double* tau, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
                                      scratchpad, scratchpad_size, dependencies));
 }
 sycl::event orgqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k, double* a,
                   std::int64_t lda, double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr(
         queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event orgqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k, float* a,
                   std::int64_t lda, float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr(
         queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event orgtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* tau, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event orgtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* tau, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -936,7 +936,7 @@ sycl::event ormtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::upl
                   oneapi::math::transpose trans, std::int64_t m, std::int64_t n, float* a,
                   std::int64_t lda, float* tau, float* c, std::int64_t ldc, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad, scratchpad_size,
         dependencies));
@@ -945,7 +945,7 @@ sycl::event ormtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::upl
                   oneapi::math::transpose trans, std::int64_t m, std::int64_t n, double* a,
                   std::int64_t lda, double* tau, double* c, std::int64_t ldc, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad, scratchpad_size,
         dependencies));
@@ -954,7 +954,7 @@ sycl::event ormrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t m, std::int64_t n, std::int64_t k, float* a, std::int64_t lda,
                   float* tau, float* c, std::int64_t ldc, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -962,7 +962,7 @@ sycl::event ormrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t m, std::int64_t n, std::int64_t k, double* a, std::int64_t lda,
                   double* tau, double* c, std::int64_t ldc, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -970,7 +970,7 @@ sycl::event ormqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t m, std::int64_t n, std::int64_t k, double* a, std::int64_t lda,
                   double* tau, double* c, std::int64_t ldc, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -978,77 +978,77 @@ sycl::event ormqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t m, std::int64_t n, std::int64_t k, float* a, std::int64_t lda,
                   float* tau, float* c, std::int64_t ldc, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potri(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   float* a, std::int64_t lda, float* b, std::int64_t ldb, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
                                                                n, nrhs, a, lda, b, ldb, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
                   double* a, std::int64_t lda, double* b, std::int64_t ldb, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
                                                                n, nrhs, a, lda, b, ldb, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1056,7 +1056,7 @@ sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, s
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* b,
                   std::int64_t ldb, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
                                                                n, nrhs, a, lda, b, ldb, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1064,21 +1064,21 @@ sycl::event potrs(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, s
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* b,
                   std::int64_t ldb, std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs(queue, detail::get_onemkl_uplo(uplo),
                                                                n, nrhs, a, lda, b, ldb, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo,
                   std::int64_t n, double* a, std::int64_t lda, double* w, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
         scratchpad, scratchpad_size, dependencies));
 }
 sycl::event syevd(sycl::queue& queue, oneapi::math::job jobz, oneapi::math::uplo uplo,
                   std::int64_t n, float* a, std::int64_t lda, float* w, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, w,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -1086,7 +1086,7 @@ sycl::event sygvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz
                   oneapi::math::uplo uplo, std::int64_t n, double* a, std::int64_t lda, double* b,
                   std::int64_t ldb, double* w, double* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size, dependencies));
 }
@@ -1094,35 +1094,35 @@ sycl::event sygvd(sycl::queue& queue, std::int64_t itype, oneapi::math::job jobz
                   oneapi::math::uplo uplo, std::int64_t n, float* a, std::int64_t lda, float* b,
                   std::int64_t ldb, float* w, float* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, a, lda, b,
         ldb, w, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event sytrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, double* d, double* e, double* tau, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, d, e, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event sytrd(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, float* d, float* e, float* tau, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, d, e, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, float* a,
                   std::int64_t lda, std::int64_t* ipiv, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
 sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, double* a,
                   std::int64_t lda, std::int64_t* ipiv, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1130,7 +1130,7 @@ sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1138,7 +1138,7 @@ sycl::event sytrf(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::int64_t* ipiv,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, ipiv, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1147,7 +1147,7 @@ sycl::event trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::tra
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* b,
                   std::int64_t ldb, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size,
         dependencies));
@@ -1156,7 +1156,7 @@ sycl::event trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::tra
                   oneapi::math::diag diag, std::int64_t n, std::int64_t nrhs, double* a,
                   std::int64_t lda, double* b, std::int64_t ldb, double* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size,
         dependencies));
@@ -1165,7 +1165,7 @@ sycl::event trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::tra
                   oneapi::math::diag diag, std::int64_t n, std::int64_t nrhs, float* a,
                   std::int64_t lda, float* b, std::int64_t ldb, float* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size,
         dependencies));
@@ -1175,7 +1175,7 @@ sycl::event trtrs(sycl::queue& queue, oneapi::math::uplo uplo, oneapi::math::tra
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* b,
                   std::int64_t ldb, std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, a, lda, b, ldb, scratchpad, scratchpad_size,
         dependencies));
@@ -1184,7 +1184,7 @@ sycl::event ungbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m
                   std::int64_t k, std::complex<float>* a, std::int64_t lda,
                   std::complex<float>* tau, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
                                      scratchpad, scratchpad_size, dependencies));
 }
@@ -1192,7 +1192,7 @@ sycl::event ungbr(sycl::queue& queue, oneapi::math::generate vec, std::int64_t m
                   std::int64_t k, std::complex<double>* a, std::int64_t lda,
                   std::complex<double>* tau, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungbr(queue, detail::get_onemkl_generate(vec), m, n, k, a, lda, tau,
                                      scratchpad, scratchpad_size, dependencies));
 }
@@ -1200,21 +1200,21 @@ sycl::event ungqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* tau,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungqr(
         queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event ungqr(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* tau,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungqr(
         queue, m, n, k, a, lda, tau, scratchpad, scratchpad_size, dependencies));
 }
 sycl::event ungtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* tau,
                   std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1222,7 +1222,7 @@ sycl::event ungtr(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* tau,
                   std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo),
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr(queue, detail::get_onemkl_uplo(uplo),
                                                                n, a, lda, tau, scratchpad,
                                                                scratchpad_size, dependencies));
 }
@@ -1231,7 +1231,7 @@ sycl::event unmrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t lda, std::complex<float>* tau, std::complex<float>* c,
                   std::int64_t ldc, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -1240,7 +1240,7 @@ sycl::event unmrq(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t lda, std::complex<double>* tau, std::complex<double>* c,
                   std::int64_t ldc, std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -1249,7 +1249,7 @@ sycl::event unmqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t lda, std::complex<float>* tau, std::complex<float>* c,
                   std::int64_t ldc, std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -1258,7 +1258,7 @@ sycl::event unmqr(sycl::queue& queue, oneapi::math::side side, oneapi::math::tra
                   std::int64_t lda, std::complex<double>* tau, std::complex<double>* c,
                   std::int64_t ldc, std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                   const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, a, lda,
         tau, c, ldc, scratchpad, scratchpad_size, dependencies));
 }
@@ -1267,7 +1267,7 @@ sycl::event unmtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::upl
                   std::complex<float>* a, std::int64_t lda, std::complex<float>* tau,
                   std::complex<float>* c, std::int64_t ldc, std::complex<float>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad, scratchpad_size,
         dependencies));
@@ -1277,7 +1277,7 @@ sycl::event unmtr(sycl::queue& queue, oneapi::math::side side, oneapi::math::upl
                   std::complex<double>* a, std::int64_t lda, std::complex<double>* tau,
                   std::complex<double>* c, std::int64_t ldc, std::complex<double>* scratchpad,
                   std::int64_t scratchpad_size, const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, a, lda, tau, c, ldc, scratchpad, scratchpad_size,
         dependencies));
@@ -1286,14 +1286,14 @@ void geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffe
                  std::int64_t lda, std::int64_t stride_a, sycl::buffer<float>& tau,
                  std::int64_t stride_tau, std::int64_t batch_size, sycl::buffer<float>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
         queue, m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad, scratchpad_size));
 }
 void geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
                  std::int64_t lda, std::int64_t stride_a, sycl::buffer<double>& tau,
                  std::int64_t stride_tau, std::int64_t batch_size, sycl::buffer<double>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
         queue, m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad, scratchpad_size));
 }
 void geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
@@ -1301,7 +1301,7 @@ void geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
                  sycl::buffer<std::complex<float>>& tau, std::int64_t stride_tau,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
         queue, m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad, scratchpad_size));
 }
 void geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
@@ -1309,35 +1309,35 @@ void geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
                  sycl::buffer<std::complex<double>>& tau, std::int64_t stride_tau,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::geqrf_batch(
         queue, m, n, a, lda, stride_a, tau, stride_tau, batch_size, scratchpad, scratchpad_size));
 }
 void getri_batch(sycl::queue& queue, std::int64_t n, sycl::buffer<float>& a, std::int64_t lda,
                  std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv, std::int64_t stride_ipiv,
                  std::int64_t batch_size, sycl::buffer<float>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
         queue, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getri_batch(sycl::queue& queue, std::int64_t n, sycl::buffer<double>& a, std::int64_t lda,
                  std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv, std::int64_t stride_ipiv,
                  std::int64_t batch_size, sycl::buffer<double>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
         queue, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getri_batch(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>>& a,
                  std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv,
                  std::int64_t stride_ipiv, std::int64_t batch_size,
                  sycl::buffer<std::complex<float>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
         queue, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getri_batch(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>>& a,
                  std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv,
                  std::int64_t stride_ipiv, std::int64_t batch_size,
                  sycl::buffer<std::complex<double>>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getri_batch(
         queue, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n,
@@ -1345,7 +1345,7 @@ void getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t
                  sycl::buffer<std::int64_t>& ipiv, std::int64_t stride_ipiv, sycl::buffer<float>& b,
                  std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                  sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size));
 }
@@ -1355,7 +1355,7 @@ void getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t
                  sycl::buffer<double>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<double>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size));
 }
@@ -1365,7 +1365,7 @@ void getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t
                  sycl::buffer<std::complex<float>>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size));
 }
@@ -1375,7 +1375,7 @@ void getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::int64_t
                  sycl::buffer<std::complex<double>>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size));
 }
@@ -1383,14 +1383,14 @@ void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffe
                  std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv,
                  std::int64_t stride_ipiv, std::int64_t batch_size, sycl::buffer<float>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
         queue, m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, sycl::buffer<double>& a,
                  std::int64_t lda, std::int64_t stride_a, sycl::buffer<std::int64_t>& ipiv,
                  std::int64_t stride_ipiv, std::int64_t batch_size,
                  sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
         queue, m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
@@ -1398,7 +1398,7 @@ void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
                  sycl::buffer<std::int64_t>& ipiv, std::int64_t stride_ipiv,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
         queue, m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
@@ -1406,14 +1406,14 @@ void getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n,
                  sycl::buffer<std::int64_t>& ipiv, std::int64_t stride_ipiv,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::getrf_batch(
         queue, m, n, a, lda, stride_a, ipiv, stride_ipiv, batch_size, scratchpad, scratchpad_size));
 }
 void orgqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k,
                  sycl::buffer<float>& a, std::int64_t lda, std::int64_t stride_a,
                  sycl::buffer<float>& tau, std::int64_t stride_tau, std::int64_t batch_size,
                  sycl::buffer<float>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a,
                                                                  tau, stride_tau, batch_size,
                                                                  scratchpad, scratchpad_size));
 }
@@ -1421,7 +1421,7 @@ void orgqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_
                  sycl::buffer<double>& a, std::int64_t lda, std::int64_t stride_a,
                  sycl::buffer<double>& tau, std::int64_t stride_tau, std::int64_t batch_size,
                  sycl::buffer<double>& scratchpad, std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a,
                                                                  tau, stride_tau, batch_size,
                                                                  scratchpad, scratchpad_size));
 }
@@ -1429,7 +1429,7 @@ void potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                  sycl::buffer<float>& a, std::int64_t lda, std::int64_t stride_a,
                  std::int64_t batch_size, sycl::buffer<float>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::potrf_batch(queue, detail::get_onemkl_uplo(uplo), n, a, lda,
                                            stride_a, batch_size, scratchpad, scratchpad_size));
 }
@@ -1437,7 +1437,7 @@ void potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                  sycl::buffer<double>& a, std::int64_t lda, std::int64_t stride_a,
                  std::int64_t batch_size, sycl::buffer<double>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::potrf_batch(queue, detail::get_onemkl_uplo(uplo), n, a, lda,
                                            stride_a, batch_size, scratchpad, scratchpad_size));
 }
@@ -1445,7 +1445,7 @@ void potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                  sycl::buffer<std::complex<float>>& a, std::int64_t lda, std::int64_t stride_a,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::potrf_batch(queue, detail::get_onemkl_uplo(uplo), n, a, lda,
                                            stride_a, batch_size, scratchpad, scratchpad_size));
 }
@@ -1453,7 +1453,7 @@ void potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n,
                  sycl::buffer<std::complex<double>>& a, std::int64_t lda, std::int64_t stride_a,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(
         ::oneapi::mkl::lapack::potrf_batch(queue, detail::get_onemkl_uplo(uplo), n, a, lda,
                                            stride_a, batch_size, scratchpad, scratchpad_size));
 }
@@ -1462,7 +1462,7 @@ void potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, st
                  sycl::buffer<float>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<float>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size));
 }
@@ -1471,7 +1471,7 @@ void potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, st
                  sycl::buffer<double>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<double>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size));
 }
@@ -1480,7 +1480,7 @@ void potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, st
                  sycl::buffer<std::complex<float>>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size));
 }
@@ -1489,7 +1489,7 @@ void potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, st
                  sycl::buffer<std::complex<double>>& b, std::int64_t ldb, std::int64_t stride_b,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size));
 }
@@ -1498,7 +1498,7 @@ void ungqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_
                  sycl::buffer<std::complex<float>>& tau, std::int64_t stride_tau,
                  std::int64_t batch_size, sycl::buffer<std::complex<float>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a,
                                                                  tau, stride_tau, batch_size,
                                                                  scratchpad, scratchpad_size));
 }
@@ -1507,7 +1507,7 @@ void ungqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_
                  sycl::buffer<std::complex<double>>& tau, std::int64_t stride_tau,
                  std::int64_t batch_size, sycl::buffer<std::complex<double>>& scratchpad,
                  std::int64_t scratchpad_size) {
-    RETHROW_ONEMKL_EXCEPTIONS(::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a,
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS(::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a,
                                                                  tau, stride_tau, batch_size,
                                                                  scratchpad, scratchpad_size));
 }
@@ -1516,7 +1516,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, floa
                         std::int64_t stride_tau, std::int64_t batch_size, float* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1525,7 +1525,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, doub
                         std::int64_t stride_tau, std::int64_t batch_size, double* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1534,7 +1534,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1543,7 +1543,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1551,7 +1551,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, fl
                         std::int64_t* lda, float** tau, std::int64_t group_count,
                         std::int64_t* group_sizes, float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1559,7 +1559,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, do
                         std::int64_t* lda, double** tau, std::int64_t group_count,
                         std::int64_t* group_sizes, double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1568,7 +1568,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n,
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1577,7 +1577,7 @@ sycl::event geqrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n,
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch(queue, m, n, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1586,7 +1586,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, floa
                         std::int64_t stride_ipiv, std::int64_t batch_size, float* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1595,7 +1595,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, doub
                         std::int64_t stride_ipiv, std::int64_t batch_size, double* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1604,7 +1604,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1613,7 +1613,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1621,7 +1621,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, fl
                         std::int64_t* lda, std::int64_t** ipiv, std::int64_t group_count,
                         std::int64_t* group_sizes, float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1629,7 +1629,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, do
                         std::int64_t* lda, std::int64_t** ipiv, std::int64_t group_count,
                         std::int64_t* group_sizes, double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1638,7 +1638,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n,
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1647,7 +1647,7 @@ sycl::event getrf_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n,
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch(queue, m, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1655,7 +1655,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t n, float* a, std::int64
                         std::int64_t stride_a, std::int64_t* ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1663,7 +1663,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t n, double* a, std::int6
                         std::int64_t stride_a, std::int64_t* ipiv, std::int64_t stride_ipiv,
                         std::int64_t batch_size, double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1672,7 +1672,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t n, std::complex<float>*
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1681,7 +1681,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t n, std::complex<double>
                         std::int64_t stride_ipiv, std::int64_t batch_size,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, stride_a, ipiv, stride_ipiv,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1689,7 +1689,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t* n, float** a, std::int
                         std::int64_t** ipiv, std::int64_t group_count, std::int64_t* group_sizes,
                         float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1697,7 +1697,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t* n, double** a, std::in
                         std::int64_t** ipiv, std::int64_t group_count, std::int64_t* group_sizes,
                         double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1706,7 +1706,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t* n, std::complex<float>
                         std::int64_t* group_sizes, std::complex<float>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1715,7 +1715,7 @@ sycl::event getri_batch(sycl::queue& queue, std::int64_t* n, std::complex<double
                         std::int64_t* group_sizes, std::complex<double>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch(queue, n, a, lda, ipiv, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1725,7 +1725,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::
                         std::int64_t stride_b, std::int64_t batch_size, float* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1735,7 +1735,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::
                         std::int64_t stride_b, std::int64_t batch_size, double* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1746,7 +1746,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::
                         std::int64_t batch_size, std::complex<float>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1757,7 +1757,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose trans, std::
                         std::int64_t batch_size, std::complex<double>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, stride_a, ipiv, stride_ipiv, b,
         ldb, stride_b, batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1766,7 +1766,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose* trans, std:
                         float** b, std::int64_t* ldb, std::int64_t group_count,
                         std::int64_t* group_sizes, float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, ipiv, b, ldb, group_count,
         group_sizes, scratchpad, scratchpad_size, dependencies));
 }
@@ -1775,7 +1775,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose* trans, std:
                         double** b, std::int64_t* ldb, std::int64_t group_count,
                         std::int64_t* group_sizes, double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, ipiv, b, ldb, group_count,
         group_sizes, scratchpad, scratchpad_size, dependencies));
 }
@@ -1785,7 +1785,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose* trans, std:
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, ipiv, b, ldb, group_count,
         group_sizes, scratchpad, scratchpad_size, dependencies));
 }
@@ -1795,7 +1795,7 @@ sycl::event getrs_batch(sycl::queue& queue, oneapi::math::transpose* trans, std:
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, a, lda, ipiv, b, ldb, group_count,
         group_sizes, scratchpad, scratchpad_size, dependencies));
 }
@@ -1804,7 +1804,7 @@ sycl::event orgqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t stride_tau, std::int64_t batch_size, float* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1813,7 +1813,7 @@ sycl::event orgqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::int64_t stride_tau, std::int64_t batch_size, double* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1821,7 +1821,7 @@ sycl::event orgqr_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, st
                         float** a, std::int64_t* lda, float** tau, std::int64_t group_count,
                         std::int64_t* group_sizes, float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1829,7 +1829,7 @@ sycl::event orgqr_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, st
                         double** a, std::int64_t* lda, double** tau, std::int64_t group_count,
                         std::int64_t* group_sizes, double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -1837,7 +1837,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size,
                         float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, stride_a, batch_size, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1845,7 +1845,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         std::int64_t lda, std::int64_t stride_a, std::int64_t batch_size,
                         double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, stride_a, batch_size, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1854,7 +1854,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         std::int64_t batch_size, std::complex<float>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, stride_a, batch_size, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1863,7 +1863,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         std::int64_t batch_size, std::complex<double>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, stride_a, batch_size, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1871,7 +1871,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* lda, std::int64_t group_count, std::int64_t* group_sizes,
                         float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1879,7 +1879,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* lda, std::int64_t group_count, std::int64_t* group_sizes,
                         double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1888,7 +1888,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* group_sizes, std::complex<float>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1897,7 +1897,7 @@ sycl::event potrf_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* group_sizes, std::complex<double>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch(
         queue, detail::get_onemkl_uplo(uplo), n, a, lda, group_count, group_sizes, scratchpad,
         scratchpad_size, dependencies));
 }
@@ -1906,7 +1906,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         float* b, std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1915,7 +1915,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         double* b, std::int64_t ldb, std::int64_t stride_b, std::int64_t batch_size,
                         double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1925,7 +1925,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1935,7 +1935,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo uplo, std::int64_
                         std::int64_t stride_b, std::int64_t batch_size,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, stride_a, b, ldb, stride_b,
         batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1944,7 +1944,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* ldb, std::int64_t group_count, std::int64_t* group_sizes,
                         float* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -1953,7 +1953,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* ldb, std::int64_t group_count, std::int64_t* group_sizes,
                         double* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -1963,7 +1963,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* group_sizes, std::complex<float>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -1973,7 +1973,7 @@ sycl::event potrs_batch(sycl::queue& queue, oneapi::math::uplo* uplo, std::int64
                         std::int64_t* group_sizes, std::complex<double>* scratchpad,
                         std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, a, lda, b, ldb, group_count, group_sizes,
         scratchpad, scratchpad_size, dependencies));
 }
@@ -1982,7 +1982,7 @@ sycl::event ungqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::complex<float>* tau, std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -1991,7 +1991,7 @@ sycl::event ungqr_batch(sycl::queue& queue, std::int64_t m, std::int64_t n, std:
                         std::complex<double>* tau, std::int64_t stride_tau, std::int64_t batch_size,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, stride_a, tau, stride_tau,
                                            batch_size, scratchpad, scratchpad_size, dependencies));
 }
@@ -2000,7 +2000,7 @@ sycl::event ungqr_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, st
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<float>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -2009,7 +2009,7 @@ sycl::event ungqr_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, st
                         std::int64_t group_count, std::int64_t* group_sizes,
                         std::complex<double>* scratchpad, std::int64_t scratchpad_size,
                         const std::vector<sycl::event>& dependencies) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch(queue, m, n, k, a, lda, tau, group_count, group_sizes,
                                            scratchpad, scratchpad_size, dependencies));
 }
@@ -2017,73 +2017,73 @@ sycl::event ungqr_batch(sycl::queue& queue, std::int64_t* m, std::int64_t* n, st
 template <>
 std::int64_t gebrd_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                           std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gebrd_scratchpad_size<float>(queue, m, n, lda));
 }
 template <>
 std::int64_t gebrd_scratchpad_size<double>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                            std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gebrd_scratchpad_size<double>(queue, m, n, lda));
 }
 template <>
 std::int64_t gebrd_scratchpad_size<std::complex<float>>(sycl::queue& queue, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gebrd_scratchpad_size<std::complex<float>>(queue, m, n, lda));
 }
 template <>
 std::int64_t gebrd_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t m,
                                                          std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gebrd_scratchpad_size<std::complex<double>>(queue, m, n, lda));
 }
 template <>
 std::int64_t gerqf_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                           std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gerqf_scratchpad_size<float>(queue, m, n, lda));
 }
 template <>
 std::int64_t gerqf_scratchpad_size<double>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                            std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gerqf_scratchpad_size<double>(queue, m, n, lda));
 }
 template <>
 std::int64_t gerqf_scratchpad_size<std::complex<float>>(sycl::queue& queue, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gerqf_scratchpad_size<std::complex<float>>(queue, m, n, lda));
 }
 template <>
 std::int64_t gerqf_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t m,
                                                          std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gerqf_scratchpad_size<std::complex<double>>(queue, m, n, lda));
 }
 template <>
 std::int64_t geqrf_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                           std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_scratchpad_size<float>(queue, m, n, lda));
 }
 template <>
 std::int64_t geqrf_scratchpad_size<double>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                            std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_scratchpad_size<double>(queue, m, n, lda));
 }
 template <>
 std::int64_t geqrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_scratchpad_size<std::complex<float>>(queue, m, n, lda));
 }
 template <>
 std::int64_t geqrf_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t m,
                                                          std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_scratchpad_size<std::complex<double>>(queue, m, n, lda));
 }
 template <>
@@ -2091,7 +2091,7 @@ std::int64_t gesvd_scratchpad_size<float>(sycl::queue& queue, oneapi::math::jobs
                                           oneapi::math::jobsvd jobvt, std::int64_t m,
                                           std::int64_t n, std::int64_t lda, std::int64_t ldu,
                                           std::int64_t ldvt) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<float>(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, lda, ldu,
         ldvt));
 }
@@ -2100,7 +2100,7 @@ std::int64_t gesvd_scratchpad_size<double>(sycl::queue& queue, oneapi::math::job
                                            oneapi::math::jobsvd jobvt, std::int64_t m,
                                            std::int64_t n, std::int64_t lda, std::int64_t ldu,
                                            std::int64_t ldvt) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<double>(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, lda, ldu,
         ldvt));
 }
@@ -2110,7 +2110,7 @@ std::int64_t gesvd_scratchpad_size<std::complex<float>>(sycl::queue& queue,
                                                         oneapi::math::jobsvd jobvt, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda,
                                                         std::int64_t ldu, std::int64_t ldvt) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, lda, ldu,
         ldvt));
 }
@@ -2120,7 +2120,7 @@ std::int64_t gesvd_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::jobsvd jobvt, std::int64_t m,
                                                          std::int64_t n, std::int64_t lda,
                                                          std::int64_t ldu, std::int64_t ldvt) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::gesvd_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_jobsvd(jobu), detail::get_onemkl_jobsvd(jobvt), m, n, lda,
             ldu, ldvt));
@@ -2128,61 +2128,61 @@ std::int64_t gesvd_scratchpad_size<std::complex<double>>(sycl::queue& queue,
 template <>
 std::int64_t getrf_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                           std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_scratchpad_size<float>(queue, m, n, lda));
 }
 template <>
 std::int64_t getrf_scratchpad_size<double>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                            std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_scratchpad_size<double>(queue, m, n, lda));
 }
 template <>
 std::int64_t getrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, std::int64_t m,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_scratchpad_size<std::complex<float>>(queue, m, n, lda));
 }
 template <>
 std::int64_t getrf_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t m,
                                                          std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_scratchpad_size<std::complex<double>>(queue, m, n, lda));
 }
 template <>
 std::int64_t getri_scratchpad_size<float>(sycl::queue& queue, std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_scratchpad_size<float>(queue, n, lda));
 }
 template <>
 std::int64_t getri_scratchpad_size<double>(sycl::queue& queue, std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_scratchpad_size<double>(queue, n, lda));
 }
 template <>
 std::int64_t getri_scratchpad_size<std::complex<float>>(sycl::queue& queue, std::int64_t n,
                                                         std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_scratchpad_size<std::complex<float>>(queue, n, lda));
 }
 template <>
 std::int64_t getri_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_scratchpad_size<std::complex<double>>(queue, n, lda));
 }
 template <>
 std::int64_t getrs_scratchpad_size<float>(sycl::queue& queue, oneapi::math::transpose trans,
                                           std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                           std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<float>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t getrs_scratchpad_size<double>(sycl::queue& queue, oneapi::math::transpose trans,
                                            std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                            std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<double>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb));
 }
 template <>
@@ -2190,7 +2190,7 @@ std::int64_t getrs_scratchpad_size<std::complex<float>>(sycl::queue& queue,
                                                         oneapi::math::transpose trans,
                                                         std::int64_t n, std::int64_t nrhs,
                                                         std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb));
 }
 template <>
@@ -2198,7 +2198,7 @@ std::int64_t getrs_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::transpose trans,
                                                          std::int64_t n, std::int64_t nrhs,
                                                          std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb));
 }
@@ -2206,14 +2206,14 @@ template <>
 std::int64_t heevd_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::job jobz,
                                                         oneapi::math::uplo uplo, std::int64_t n,
                                                         std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t heevd_scratchpad_size<std::complex<double>>(sycl::queue& queue, oneapi::math::job jobz,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::heevd_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda));
 }
@@ -2222,7 +2222,7 @@ std::int64_t hegvd_scratchpad_size<std::complex<float>>(sycl::queue& queue, std:
                                                         oneapi::math::job jobz,
                                                         oneapi::math::uplo uplo, std::int64_t n,
                                                         std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<float>>(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda, ldb));
 }
 template <>
@@ -2230,7 +2230,7 @@ std::int64_t hegvd_scratchpad_size<std::complex<double>>(sycl::queue& queue, std
                                                          oneapi::math::job jobz,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::hegvd_scratchpad_size<std::complex<double>>(
             queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda,
             ldb));
@@ -2238,28 +2238,28 @@ std::int64_t hegvd_scratchpad_size<std::complex<double>>(sycl::queue& queue, std
 template <>
 std::int64_t hetrd_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrd_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t hetrd_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::hetrd_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t hetrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::hetrf_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t hetrf_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::hetrf_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
@@ -2267,38 +2267,38 @@ template <>
 std::int64_t orgbr_scratchpad_size<float>(sycl::queue& queue, oneapi::math::generate vect,
                                           std::int64_t m, std::int64_t n, std::int64_t k,
                                           std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgbr_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgbr_scratchpad_size<float>(
         queue, detail::get_onemkl_generate(vect), m, n, k, lda));
 }
 template <>
 std::int64_t orgbr_scratchpad_size<double>(sycl::queue& queue, oneapi::math::generate vect,
                                            std::int64_t m, std::int64_t n, std::int64_t k,
                                            std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgbr_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgbr_scratchpad_size<double>(
         queue, detail::get_onemkl_generate(vect), m, n, k, lda));
 }
 template <>
 std::int64_t orgtr_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t orgtr_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgtr_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t orgqr_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                           std::int64_t k, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgqr_scratchpad_size<float>(queue, m, n, k, lda));
 }
 template <>
 std::int64_t orgqr_scratchpad_size<double>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                            std::int64_t k, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::orgqr_scratchpad_size<double>(queue, m, n, k, lda));
 }
 template <>
@@ -2306,7 +2306,7 @@ std::int64_t ormrq_scratchpad_size<float>(sycl::queue& queue, oneapi::math::side
                                           oneapi::math::transpose trans, std::int64_t m,
                                           std::int64_t n, std::int64_t k, std::int64_t lda,
                                           std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq_scratchpad_size<float>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
         ldc));
 }
@@ -2315,7 +2315,7 @@ std::int64_t ormrq_scratchpad_size<double>(sycl::queue& queue, oneapi::math::sid
                                            oneapi::math::transpose trans, std::int64_t m,
                                            std::int64_t n, std::int64_t k, std::int64_t lda,
                                            std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormrq_scratchpad_size<double>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
         ldc));
 }
@@ -2324,7 +2324,7 @@ std::int64_t ormqr_scratchpad_size<float>(sycl::queue& queue, oneapi::math::side
                                           oneapi::math::transpose trans, std::int64_t m,
                                           std::int64_t n, std::int64_t k, std::int64_t lda,
                                           std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr_scratchpad_size<float>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
         ldc));
 }
@@ -2333,7 +2333,7 @@ std::int64_t ormqr_scratchpad_size<double>(sycl::queue& queue, oneapi::math::sid
                                            oneapi::math::transpose trans, std::int64_t m,
                                            std::int64_t n, std::int64_t k, std::int64_t lda,
                                            std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormqr_scratchpad_size<double>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
         ldc));
 }
@@ -2342,7 +2342,7 @@ std::int64_t ormtr_scratchpad_size<float>(sycl::queue& queue, oneapi::math::side
                                           oneapi::math::uplo uplo, oneapi::math::transpose trans,
                                           std::int64_t m, std::int64_t n, std::int64_t lda,
                                           std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr_scratchpad_size<float>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, lda, ldc));
 }
@@ -2351,33 +2351,33 @@ std::int64_t ormtr_scratchpad_size<double>(sycl::queue& queue, oneapi::math::sid
                                            oneapi::math::uplo uplo, oneapi::math::transpose trans,
                                            std::int64_t m, std::int64_t n, std::int64_t lda,
                                            std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ormtr_scratchpad_size<double>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, lda, ldc));
 }
 template <>
 std::int64_t potrf_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potrf_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potrf_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrf_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
@@ -2385,21 +2385,21 @@ template <>
 std::int64_t potrs_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                           std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t potrs_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                            std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t potrs_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t nrhs,
                                                         std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb));
 }
 template <>
@@ -2407,59 +2407,59 @@ std::int64_t potrs_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t nrhs, std::int64_t lda,
                                                          std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrs_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb));
 }
 template <>
 std::int64_t potri_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potri_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potri_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potri_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t potri_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potri_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sytrf_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sytrf_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sytrf_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrf_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sytrf_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::sytrf_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
@@ -2467,40 +2467,40 @@ template <>
 std::int64_t syevd_scratchpad_size<float>(sycl::queue& queue, oneapi::math::job jobz,
                                           oneapi::math::uplo uplo, std::int64_t n,
                                           std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd_scratchpad_size<float>(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t syevd_scratchpad_size<double>(sycl::queue& queue, oneapi::math::job jobz,
                                            oneapi::math::uplo uplo, std::int64_t n,
                                            std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::syevd_scratchpad_size<double>(
         queue, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sygvd_scratchpad_size<float>(sycl::queue& queue, std::int64_t itype,
                                           oneapi::math::job jobz, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd_scratchpad_size<float>(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda, ldb));
 }
 template <>
 std::int64_t sygvd_scratchpad_size<double>(sycl::queue& queue, std::int64_t itype,
                                            oneapi::math::job jobz, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t lda, std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sygvd_scratchpad_size<double>(
         queue, itype, detail::get_onemkl_job(jobz), detail::get_onemkl_uplo(uplo), n, lda, ldb));
 }
 template <>
 std::int64_t sytrd_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                           std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t sytrd_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                            std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::sytrd_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
@@ -2508,7 +2508,7 @@ std::int64_t trtrs_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo
                                           oneapi::math::transpose trans, oneapi::math::diag diag,
                                           std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                           std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, lda, ldb));
 }
@@ -2517,7 +2517,7 @@ std::int64_t trtrs_scratchpad_size<double>(sycl::queue& queue, oneapi::math::upl
                                            oneapi::math::transpose trans, oneapi::math::diag diag,
                                            std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                            std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, lda, ldb));
 }
@@ -2527,7 +2527,7 @@ std::int64_t trtrs_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         oneapi::math::diag diag, std::int64_t n,
                                                         std::int64_t nrhs, std::int64_t lda,
                                                         std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::trtrs_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
         detail::get_onemkl_diag(diag), n, nrhs, lda, ldb));
 }
@@ -2538,7 +2538,7 @@ std::int64_t trtrs_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::diag diag, std::int64_t n,
                                                          std::int64_t nrhs, std::int64_t lda,
                                                          std::int64_t ldb) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::trtrs_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), detail::get_onemkl_transpose(trans),
             detail::get_onemkl_diag(diag), n, nrhs, lda, ldb));
@@ -2548,7 +2548,7 @@ std::int64_t ungbr_scratchpad_size<std::complex<float>>(sycl::queue& queue,
                                                         oneapi::math::generate vect, std::int64_t m,
                                                         std::int64_t n, std::int64_t k,
                                                         std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_generate(vect), m, n, k, lda));
 }
 template <>
@@ -2556,7 +2556,7 @@ std::int64_t ungbr_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::generate vect,
                                                          std::int64_t m, std::int64_t n,
                                                          std::int64_t k, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungbr_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_generate(vect), m, n, k, lda));
 }
@@ -2564,27 +2564,27 @@ template <>
 std::int64_t ungqr_scratchpad_size<std::complex<float>>(sycl::queue& queue, std::int64_t m,
                                                         std::int64_t n, std::int64_t k,
                                                         std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_scratchpad_size<std::complex<float>>(queue, m, n, k, lda));
 }
 template <>
 std::int64_t ungqr_scratchpad_size<std::complex<double>>(sycl::queue& queue, std::int64_t m,
                                                          std::int64_t n, std::int64_t k,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_scratchpad_size<std::complex<double>>(queue, m, n, k, lda));
 }
 template <>
 std::int64_t ungtr_scratchpad_size<std::complex<float>>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                         std::int64_t n, std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::ungtr_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
 template <>
 std::int64_t ungtr_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::uplo uplo, std::int64_t n,
                                                          std::int64_t lda) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungtr_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda));
 }
@@ -2594,7 +2594,7 @@ std::int64_t unmrq_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         std::int64_t m, std::int64_t n,
                                                         std::int64_t k, std::int64_t lda,
                                                         std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmrq_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
         ldc));
 }
@@ -2602,7 +2602,7 @@ template <>
 std::int64_t unmrq_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose trans, std::int64_t m,
     std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::unmrq_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
             ldc));
@@ -2613,7 +2613,7 @@ std::int64_t unmqr_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         std::int64_t m, std::int64_t n,
                                                         std::int64_t k, std::int64_t lda,
                                                         std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
         ldc));
 }
@@ -2621,7 +2621,7 @@ template <>
 std::int64_t unmqr_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, oneapi::math::side side, oneapi::math::transpose trans, std::int64_t m,
     std::int64_t n, std::int64_t k, std::int64_t lda, std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::unmqr_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_side(side), detail::get_onemkl_transpose(trans), m, n, k, lda,
             ldc));
@@ -2632,7 +2632,7 @@ std::int64_t unmtr_scratchpad_size<std::complex<float>>(sycl::queue& queue, onea
                                                         oneapi::math::transpose trans,
                                                         std::int64_t m, std::int64_t n,
                                                         std::int64_t lda, std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<float>>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<float>>(
         queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
         detail::get_onemkl_transpose(trans), m, n, lda, ldc));
 }
@@ -2643,7 +2643,7 @@ std::int64_t unmtr_scratchpad_size<std::complex<double>>(sycl::queue& queue,
                                                          oneapi::math::transpose trans,
                                                          std::int64_t m, std::int64_t n,
                                                          std::int64_t lda, std::int64_t ldc) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::unmtr_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_side(side), detail::get_onemkl_uplo(uplo),
             detail::get_onemkl_transpose(trans), m, n, lda, ldc));
@@ -2652,7 +2652,7 @@ template <>
 std::int64_t getrf_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                                 std::int64_t lda, std::int64_t stride_a,
                                                 std::int64_t stride_ipiv, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<float>(
         queue, m, n, lda, stride_a, stride_ipiv, batch_size));
 }
 template <>
@@ -2660,7 +2660,7 @@ std::int64_t getrf_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_
                                                  std::int64_t lda, std::int64_t stride_a,
                                                  std::int64_t stride_ipiv,
                                                  std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<double>(
         queue, m, n, lda, stride_a, stride_ipiv, batch_size));
 }
 template <>
@@ -2669,7 +2669,7 @@ std::int64_t getrf_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t stride_a,
                                                               std::int64_t stride_ipiv,
                                                               std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch_scratchpad_size<std::complex<float>>(
             queue, m, n, lda, stride_a, stride_ipiv, batch_size));
 }
@@ -2679,7 +2679,7 @@ std::int64_t getrf_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t stride_a,
                                                                std::int64_t stride_ipiv,
                                                                std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch_scratchpad_size<std::complex<double>>(
             queue, m, n, lda, stride_a, stride_ipiv, batch_size));
 }
@@ -2687,7 +2687,7 @@ template <>
 std::int64_t getri_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t n,
                                                 std::int64_t lda, std::int64_t stride_a,
                                                 std::int64_t stride_ipiv, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<float>(
         queue, n, lda, stride_a, stride_ipiv, batch_size));
 }
 template <>
@@ -2695,7 +2695,7 @@ std::int64_t getri_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_
                                                  std::int64_t lda, std::int64_t stride_a,
                                                  std::int64_t stride_ipiv,
                                                  std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<double>(
         queue, n, lda, stride_a, stride_ipiv, batch_size));
 }
 template <>
@@ -2704,7 +2704,7 @@ std::int64_t getri_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t stride_a,
                                                               std::int64_t stride_ipiv,
                                                               std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch_scratchpad_size<std::complex<float>>(
             queue, n, lda, stride_a, stride_ipiv, batch_size));
 }
@@ -2714,7 +2714,7 @@ std::int64_t getri_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t stride_a,
                                                                std::int64_t stride_ipiv,
                                                                std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch_scratchpad_size<std::complex<double>>(
             queue, n, lda, stride_a, stride_ipiv, batch_size));
 }
@@ -2724,7 +2724,7 @@ std::int64_t getrs_batch_scratchpad_size<float>(sycl::queue& queue, oneapi::math
                                                 std::int64_t stride_a, std::int64_t stride_ipiv,
                                                 std::int64_t ldb, std::int64_t stride_b,
                                                 std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<float>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, stride_a, stride_ipiv, ldb,
         stride_b, batch_size));
 }
@@ -2734,7 +2734,7 @@ std::int64_t getrs_batch_scratchpad_size<double>(sycl::queue& queue, oneapi::mat
                                                  std::int64_t lda, std::int64_t stride_a,
                                                  std::int64_t stride_ipiv, std::int64_t ldb,
                                                  std::int64_t stride_b, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<double>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, stride_a, stride_ipiv, ldb,
         stride_b, batch_size));
 }
@@ -2743,7 +2743,7 @@ std::int64_t getrs_batch_scratchpad_size<std::complex<float>>(
     sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
     std::int64_t lda, std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t ldb,
     std::int64_t stride_b, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs_batch_scratchpad_size<std::complex<float>>(
             queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, stride_a, stride_ipiv, ldb,
             stride_b, batch_size));
@@ -2753,7 +2753,7 @@ std::int64_t getrs_batch_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, oneapi::math::transpose trans, std::int64_t n, std::int64_t nrhs,
     std::int64_t lda, std::int64_t stride_a, std::int64_t stride_ipiv, std::int64_t ldb,
     std::int64_t stride_b, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs_batch_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, stride_a, stride_ipiv, ldb,
             stride_b, batch_size));
@@ -2762,14 +2762,14 @@ template <>
 std::int64_t geqrf_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                                 std::int64_t lda, std::int64_t stride_a,
                                                 std::int64_t stride_tau, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<float>(
         queue, m, n, lda, stride_a, stride_tau, batch_size));
 }
 template <>
 std::int64_t geqrf_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_t m, std::int64_t n,
                                                  std::int64_t lda, std::int64_t stride_a,
                                                  std::int64_t stride_tau, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<double>(
         queue, m, n, lda, stride_a, stride_tau, batch_size));
 }
 template <>
@@ -2778,7 +2778,7 @@ std::int64_t geqrf_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t stride_a,
                                                               std::int64_t stride_tau,
                                                               std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<std::complex<float>>(
             queue, m, n, lda, stride_a, stride_tau, batch_size));
 }
@@ -2788,7 +2788,7 @@ std::int64_t geqrf_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t stride_a,
                                                                std::int64_t stride_tau,
                                                                std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<std::complex<double>>(
             queue, m, n, lda, stride_a, stride_tau, batch_size));
 }
@@ -2796,14 +2796,14 @@ template <>
 std::int64_t potrf_batch_scratchpad_size<float>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                 std::int64_t n, std::int64_t lda,
                                                 std::int64_t stride_a, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda, stride_a, batch_size));
 }
 template <>
 std::int64_t potrf_batch_scratchpad_size<double>(sycl::queue& queue, oneapi::math::uplo uplo,
                                                  std::int64_t n, std::int64_t lda,
                                                  std::int64_t stride_a, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda, stride_a, batch_size));
 }
 template <>
@@ -2812,7 +2812,7 @@ std::int64_t potrf_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t n, std::int64_t lda,
                                                               std::int64_t stride_a,
                                                               std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrf_batch_scratchpad_size<std::complex<float>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda, stride_a, batch_size));
 }
@@ -2822,7 +2822,7 @@ std::int64_t potrf_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t n, std::int64_t lda,
                                                                std::int64_t stride_a,
                                                                std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrf_batch_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda, stride_a, batch_size));
 }
@@ -2831,7 +2831,7 @@ std::int64_t potrs_batch_scratchpad_size<float>(sycl::queue& queue, oneapi::math
                                                 std::int64_t n, std::int64_t nrhs, std::int64_t lda,
                                                 std::int64_t stride_a, std::int64_t ldb,
                                                 std::int64_t stride_b, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, stride_a, ldb, stride_b, batch_size));
 }
 template <>
@@ -2840,7 +2840,7 @@ std::int64_t potrs_batch_scratchpad_size<double>(sycl::queue& queue, oneapi::mat
                                                  std::int64_t lda, std::int64_t stride_a,
                                                  std::int64_t ldb, std::int64_t stride_b,
                                                  std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, stride_a, ldb, stride_b, batch_size));
 }
 template <>
@@ -2848,7 +2848,7 @@ std::int64_t potrs_batch_scratchpad_size<std::complex<float>>(
     sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
     std::int64_t lda, std::int64_t stride_a, std::int64_t ldb, std::int64_t stride_b,
     std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrs_batch_scratchpad_size<std::complex<float>>(
             queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, stride_a, ldb, stride_b,
             batch_size));
@@ -2858,7 +2858,7 @@ std::int64_t potrs_batch_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, oneapi::math::uplo uplo, std::int64_t n, std::int64_t nrhs,
     std::int64_t lda, std::int64_t stride_a, std::int64_t ldb, std::int64_t stride_b,
     std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrs_batch_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, stride_a, ldb, stride_b,
             batch_size));
@@ -2868,7 +2868,7 @@ std::int64_t orgqr_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t
                                                 std::int64_t k, std::int64_t lda,
                                                 std::int64_t stride_a, std::int64_t stride_tau,
                                                 std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<float>(
         queue, m, n, k, lda, stride_a, stride_tau, batch_size));
 }
 template <>
@@ -2876,14 +2876,14 @@ std::int64_t orgqr_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_
                                                  std::int64_t k, std::int64_t lda,
                                                  std::int64_t stride_a, std::int64_t stride_tau,
                                                  std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<double>(
         queue, m, n, k, lda, stride_a, stride_tau, batch_size));
 }
 template <>
 std::int64_t ungqr_batch_scratchpad_size<std::complex<float>>(
     sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
     std::int64_t stride_a, std::int64_t stride_tau, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch_scratchpad_size<std::complex<float>>(
             queue, m, n, k, lda, stride_a, stride_tau, batch_size));
 }
@@ -2891,7 +2891,7 @@ template <>
 std::int64_t ungqr_batch_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, std::int64_t m, std::int64_t n, std::int64_t k, std::int64_t lda,
     std::int64_t stride_a, std::int64_t stride_tau, std::int64_t batch_size) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch_scratchpad_size<std::complex<double>>(
             queue, m, n, k, lda, stride_a, stride_tau, batch_size));
 }
@@ -2900,7 +2900,7 @@ std::int64_t getrf_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t
                                                 std::int64_t* n, std::int64_t* lda,
                                                 std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<float>(
         queue, m, n, lda, group_count, group_sizes));
 }
 template <>
@@ -2908,7 +2908,7 @@ std::int64_t getrf_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_
                                                  std::int64_t* n, std::int64_t* lda,
                                                  std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrf_batch_scratchpad_size<double>(
         queue, m, n, lda, group_count, group_sizes));
 }
 template <>
@@ -2916,7 +2916,7 @@ std::int64_t getrf_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t* n, std::int64_t* lda,
                                                               std::int64_t group_count,
                                                               std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch_scratchpad_size<std::complex<float>>(
             queue, m, n, lda, group_count, group_sizes));
 }
@@ -2925,7 +2925,7 @@ std::int64_t getrf_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t* n, std::int64_t* lda,
                                                                std::int64_t group_count,
                                                                std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrf_batch_scratchpad_size<std::complex<double>>(
             queue, m, n, lda, group_count, group_sizes));
 }
@@ -2933,14 +2933,14 @@ template <>
 std::int64_t getri_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t* n,
                                                 std::int64_t* lda, std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<float>(
         queue, n, lda, group_count, group_sizes));
 }
 template <>
 std::int64_t getri_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_t* n,
                                                  std::int64_t* lda, std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getri_batch_scratchpad_size<double>(
         queue, n, lda, group_count, group_sizes));
 }
 template <>
@@ -2948,7 +2948,7 @@ std::int64_t getri_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t* lda,
                                                               std::int64_t group_count,
                                                               std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch_scratchpad_size<std::complex<float>>(
             queue, n, lda, group_count, group_sizes));
 }
@@ -2957,7 +2957,7 @@ std::int64_t getri_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t* lda,
                                                                std::int64_t group_count,
                                                                std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getri_batch_scratchpad_size<std::complex<double>>(
             queue, n, lda, group_count, group_sizes));
 }
@@ -2967,7 +2967,7 @@ std::int64_t getrs_batch_scratchpad_size<float>(sycl::queue& queue, oneapi::math
                                                 std::int64_t* lda, std::int64_t* ldb,
                                                 std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<float>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb, group_count, group_sizes));
 }
 template <>
@@ -2976,14 +2976,14 @@ std::int64_t getrs_batch_scratchpad_size<double>(sycl::queue& queue, oneapi::mat
                                                  std::int64_t* lda, std::int64_t* ldb,
                                                  std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::getrs_batch_scratchpad_size<double>(
         queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb, group_count, group_sizes));
 }
 template <>
 std::int64_t getrs_batch_scratchpad_size<std::complex<float>>(
     sycl::queue& queue, oneapi::math::transpose* trans, std::int64_t* n, std::int64_t* nrhs,
     std::int64_t* lda, std::int64_t* ldb, std::int64_t group_count, std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs_batch_scratchpad_size<std::complex<float>>(
             queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb, group_count,
             group_sizes));
@@ -2992,7 +2992,7 @@ template <>
 std::int64_t getrs_batch_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, oneapi::math::transpose* trans, std::int64_t* n, std::int64_t* nrhs,
     std::int64_t* lda, std::int64_t* ldb, std::int64_t group_count, std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::getrs_batch_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_transpose(trans), n, nrhs, lda, ldb, group_count,
             group_sizes));
@@ -3002,7 +3002,7 @@ std::int64_t geqrf_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t
                                                 std::int64_t* n, std::int64_t* lda,
                                                 std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<float>(
         queue, m, n, lda, group_count, group_sizes));
 }
 template <>
@@ -3010,7 +3010,7 @@ std::int64_t geqrf_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_
                                                  std::int64_t* n, std::int64_t* lda,
                                                  std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<double>(
         queue, m, n, lda, group_count, group_sizes));
 }
 template <>
@@ -3018,7 +3018,7 @@ std::int64_t geqrf_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t* n, std::int64_t* lda,
                                                               std::int64_t group_count,
                                                               std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<std::complex<float>>(
             queue, m, n, lda, group_count, group_sizes));
 }
@@ -3027,7 +3027,7 @@ std::int64_t geqrf_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t* n, std::int64_t* lda,
                                                                std::int64_t group_count,
                                                                std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::geqrf_batch_scratchpad_size<std::complex<double>>(
             queue, m, n, lda, group_count, group_sizes));
 }
@@ -3036,7 +3036,7 @@ std::int64_t orgqr_batch_scratchpad_size<float>(sycl::queue& queue, std::int64_t
                                                 std::int64_t* n, std::int64_t* k, std::int64_t* lda,
                                                 std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<float>(
         queue, m, n, k, lda, group_count, group_sizes));
 }
 template <>
@@ -3044,7 +3044,7 @@ std::int64_t orgqr_batch_scratchpad_size<double>(sycl::queue& queue, std::int64_
                                                  std::int64_t* n, std::int64_t* k,
                                                  std::int64_t* lda, std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::orgqr_batch_scratchpad_size<double>(
         queue, m, n, k, lda, group_count, group_sizes));
 }
 template <>
@@ -3052,7 +3052,7 @@ std::int64_t potrf_batch_scratchpad_size<float>(sycl::queue& queue, oneapi::math
                                                 std::int64_t* n, std::int64_t* lda,
                                                 std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, lda, group_count, group_sizes));
 }
 template <>
@@ -3060,7 +3060,7 @@ std::int64_t potrf_batch_scratchpad_size<double>(sycl::queue& queue, oneapi::mat
                                                  std::int64_t* n, std::int64_t* lda,
                                                  std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrf_batch_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, lda, group_count, group_sizes));
 }
 template <>
@@ -3069,7 +3069,7 @@ std::int64_t potrf_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t* n, std::int64_t* lda,
                                                               std::int64_t group_count,
                                                               std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrf_batch_scratchpad_size<std::complex<float>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda, group_count, group_sizes));
 }
@@ -3079,7 +3079,7 @@ std::int64_t potrf_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t* n, std::int64_t* lda,
                                                                std::int64_t group_count,
                                                                std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrf_batch_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, lda, group_count, group_sizes));
 }
@@ -3089,7 +3089,7 @@ std::int64_t potrs_batch_scratchpad_size<float>(sycl::queue& queue, oneapi::math
                                                 std::int64_t* lda, std::int64_t* ldb,
                                                 std::int64_t group_count,
                                                 std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<float>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<float>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb, group_count, group_sizes));
 }
 template <>
@@ -3098,14 +3098,14 @@ std::int64_t potrs_batch_scratchpad_size<double>(sycl::queue& queue, oneapi::mat
                                                  std::int64_t* lda, std::int64_t* ldb,
                                                  std::int64_t group_count,
                                                  std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<double>(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(::oneapi::mkl::lapack::potrs_batch_scratchpad_size<double>(
         queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb, group_count, group_sizes));
 }
 template <>
 std::int64_t potrs_batch_scratchpad_size<std::complex<float>>(
     sycl::queue& queue, oneapi::math::uplo* uplo, std::int64_t* n, std::int64_t* nrhs,
     std::int64_t* lda, std::int64_t* ldb, std::int64_t group_count, std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrs_batch_scratchpad_size<std::complex<float>>(
             queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb, group_count, group_sizes));
 }
@@ -3113,7 +3113,7 @@ template <>
 std::int64_t potrs_batch_scratchpad_size<std::complex<double>>(
     sycl::queue& queue, oneapi::math::uplo* uplo, std::int64_t* n, std::int64_t* nrhs,
     std::int64_t* lda, std::int64_t* ldb, std::int64_t group_count, std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::potrs_batch_scratchpad_size<std::complex<double>>(
             queue, detail::get_onemkl_uplo(uplo), n, nrhs, lda, ldb, group_count, group_sizes));
 }
@@ -3123,7 +3123,7 @@ std::int64_t ungqr_batch_scratchpad_size<std::complex<float>>(sycl::queue& queue
                                                               std::int64_t* lda,
                                                               std::int64_t group_count,
                                                               std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch_scratchpad_size<std::complex<float>>(
             queue, m, n, k, lda, group_count, group_sizes));
 }
@@ -3133,7 +3133,7 @@ std::int64_t ungqr_batch_scratchpad_size<std::complex<double>>(sycl::queue& queu
                                                                std::int64_t* lda,
                                                                std::int64_t group_count,
                                                                std::int64_t* group_sizes) {
-    RETHROW_ONEMKL_EXCEPTIONS_RET(
+    RETHROW_ONEMKL_LAPACK_EXCEPTIONS_RET(
         ::oneapi::mkl::lapack::ungqr_batch_scratchpad_size<std::complex<double>>(
             queue, m, n, k, lda, group_count, group_sizes));
 }


### PR DESCRIPTION
# Description
During the change from oneMKL to oneMath LAPACK specific exceptions were not properly treated (see https://github.com/uxlfoundation/oneMath/issues/642). This PR fixes this issue.

# Fixes (https://github.com/uxlfoundation/oneMath/issues/642)
Following fixes were made to achieve this:
* Extended LAPACK specific exception constructors to directly accept message
* Introduced new macros for handling LAPACK specific exceptions
* Modified all LAPACK routines to call the new domain specific macro

# Checklist

## All Submissions
- [x] Do all unit tests pass locally? Yes. 
[ctest_lapack.log](https://github.com/user-attachments/files/19781561/ctest_lapack.log)

- [x] clang-format? Yes
