### PR TITLE
[DFT] Support AdaptiveCpp in cuFFT and rocFFT backends

### DIFF
--- a/README.md
+++ b/README.md
@@ -338,7 +338,7 @@ Supported compilers include:
         <tr>
             <td rowspan=2 align="center">NVIDIA GPU</td>
             <td align="center">NVIDIA cuFFT</td>
-            <td align="center">Open DPC++</td>
+            <td align="center">Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>
@@ -349,7 +349,7 @@ Supported compilers include:
         <tr>
             <td rowspan=2 align="center">AMD GPU</td>
             <td align="center">AMD rocFFT</td>
-            <td align="center">Open DPC++</td>
+            <td align="center">Open DPC++</br>AdaptiveCpp</td>
             <td align="center">Dynamic, Static</td>
         </tr>
         <tr>

--- a/docs/building_the_project_with_adaptivecpp.rst
+++ b/docs/building_the_project_with_adaptivecpp.rst
@@ -57,7 +57,7 @@ additional guidance. The target architectures must be specified with
 ``HIP_TARGETS``. See the `AdaptiveCpp documentation
 <https://github.com/AdaptiveCpp/AdaptiveCpp/blob/develop/doc/using-hipsycl.md#adaptivecpp-targets-specification>`_.
 
-If a backend library supports multiple domains (i.e. BLAS, RNG), it may be
+If a backend library supports multiple domains (i.e. BLAS, DFT, RNG), it may be
 desirable to only enable selected domains. For this, the ``TARGET_DOMAINS``
 variable should be set. For further details, see :ref:`_build_target_domains`.
 
@@ -81,6 +81,9 @@ The most important supported build options are:
    * - ENABLE_CUBLAS_BACKEND
      - True, False
      - False     
+   * - ENABLE_CUFFT_BACKEND
+     - True, False
+     - False
    * - ENABLE_CURAND_BACKEND
      - True, False
      - False     
@@ -93,6 +96,9 @@ The most important supported build options are:
    * - ENABLE_ROCBLAS_BACKEND
      - True, False
      - False     
+   * - ENABLE_ROCFFT_BACKEND
+     - True, False
+     - False
    * - ENABLE_ROCRAND_BACKEND
      - True, False
      - False     
@@ -106,7 +112,7 @@ The most important supported build options are:
      - True, False
      - True      
    * - TARGET_DOMAINS (list)
-     - blas, rng
+     - blas, dft, rng
      - All supported domains
 
 Some additional build options are given in
@@ -120,8 +126,8 @@ Backends
 Building for CUDA
 ~~~~~~~~~~~~~~~~~
 
-The CUDA backends can be enabled with ``ENABLE_CUBLAS_BACKEND`` and
-``ENABLE_CURAND_BACKEND``.
+The CUDA backends can be enabled with ``ENABLE_CUBLAS_BACKEND``,
+``ENABLE_CUFFT_BACKEND`` and ``ENABLE_CURAND_BACKEND``.
 
 The target architecture must be set using the ``HIPSYCL_TARGETS`` parameter. For
 example, to target a Nvidia A100 (Ampere architecture), set
@@ -140,8 +146,8 @@ the CUDA libraries should be found automatically by CMake.
 Building for ROCm
 ~~~~~~~~~~~~~~~~~
 
-The ROCm backends can be enabled with ``ENABLE_ROCBLAS_BACKEND`` and
-``ENABLE_ROCRAND_BACKEND``.
+The ROCm backends can be enabled with ``ENABLE_ROCBLAS_BACKEND``,
+``ENABLE_ROCFFT_BACKEND`` and ``ENABLE_ROCRAND_BACKEND``.
 
 The target architecture must be set using the ``HIPSYCL_TARGETS`` parameter. See
 the `AdaptiveCpp documentation

--- a/src/dft/backends/cufft/backward.cpp
+++ b/src/dft/backends/cufft/backward.cpp
@@ -76,7 +76,7 @@ ONEMATH_EXPORT void compute_backward(descriptor_type& desc,
             auto stream = detail::setup_stream(func_name, ih, plan);
 
             auto inout_native = reinterpret_cast<fwd<descriptor_type>*>(
-                ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(inout_acc));
+                ih.get_native_mem<detail::sycl_cuda_backend>(inout_acc));
             detail::cufft_execute<detail::Direction::Backward, fwd<descriptor_type>>(
                 func_name, stream, plan, reinterpret_cast<void*>(inout_native + offsets[0]),
                 reinterpret_cast<void*>(inout_native + offsets[1]));
@@ -123,11 +123,11 @@ ONEMATH_EXPORT void compute_backward(descriptor_type& desc,
 
             auto in_native = reinterpret_cast<void*>(
                 reinterpret_cast<bwd<descriptor_type>*>(
-                    ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(in_acc)) +
+                    ih.get_native_mem<detail::sycl_cuda_backend>(in_acc)) +
                 offsets[0]);
             auto out_native = reinterpret_cast<void*>(
                 reinterpret_cast<fwd<descriptor_type>*>(
-                    ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(out_acc)) +
+                    ih.get_native_mem<detail::sycl_cuda_backend>(out_acc)) +
                 offsets[1]);
             detail::cufft_execute<detail::Direction::Backward, fwd<descriptor_type>>(
                 func_name, stream, plan, in_native, out_native);

--- a/src/dft/backends/cufft/backward.cpp
+++ b/src/dft/backends/cufft/backward.cpp
@@ -121,14 +121,14 @@ ONEMATH_EXPORT void compute_backward(descriptor_type& desc,
         dft::detail::fft_enqueue_task(cgh, [=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
 
-            auto in_native = reinterpret_cast<void*>(
-                reinterpret_cast<bwd<descriptor_type>*>(
-                    ih.get_native_mem<detail::sycl_cuda_backend>(in_acc)) +
-                offsets[0]);
-            auto out_native = reinterpret_cast<void*>(
-                reinterpret_cast<fwd<descriptor_type>*>(
-                    ih.get_native_mem<detail::sycl_cuda_backend>(out_acc)) +
-                offsets[1]);
+            auto in_native =
+                reinterpret_cast<void*>(reinterpret_cast<bwd<descriptor_type>*>(
+                                            ih.get_native_mem<detail::sycl_cuda_backend>(in_acc)) +
+                                        offsets[0]);
+            auto out_native =
+                reinterpret_cast<void*>(reinterpret_cast<fwd<descriptor_type>*>(
+                                            ih.get_native_mem<detail::sycl_cuda_backend>(out_acc)) +
+                                        offsets[1]);
             detail::cufft_execute<detail::Direction::Backward, fwd<descriptor_type>>(
                 func_name, stream, plan, in_native, out_native);
         });

--- a/src/dft/backends/cufft/execute_helper.hpp
+++ b/src/dft/backends/cufft/execute_helper.hpp
@@ -36,6 +36,12 @@
 
 namespace oneapi::math::dft::cufft::detail {
 
+#ifdef __ADAPTIVECPP__
+constexpr auto sycl_cuda_backend{sycl::backend::cuda};
+#else // DPC++
+constexpr auto sycl_cuda_backend{sycl::backend::ext_oneapi_cuda};
+#endif
+
 template <dft::precision prec, dft::domain dom>
 inline dft::detail::commit_impl<prec, dom>* checked_get_commit(
     dft::detail::descriptor<prec, dom>& desc) {
@@ -142,7 +148,7 @@ void cufft_execute(const std::string& func, CUstream stream, cufftHandle plan, v
 }
 
 inline CUstream setup_stream(const std::string& func, sycl::interop_handle ih, cufftHandle plan) {
-    auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
+    auto stream = ih.get_native_queue<sycl_cuda_backend>();
     auto result = cufftSetStream(plan, stream);
     if (result != CUFFT_SUCCESS) {
         throw oneapi::math::exception("dft/backends/cufft", func,

--- a/src/dft/backends/cufft/execute_helper.hpp
+++ b/src/dft/backends/cufft/execute_helper.hpp
@@ -36,7 +36,7 @@
 
 namespace oneapi::math::dft::cufft::detail {
 
-#if defined(__ADAPTIVECPP__) || defined (__HIPSYCL__)
+#if defined(__ADAPTIVECPP__) || defined(__HIPSYCL__)
 constexpr auto sycl_cuda_backend{ sycl::backend::cuda };
 #else // DPC++
 constexpr auto sycl_cuda_backend{ sycl::backend::ext_oneapi_cuda };

--- a/src/dft/backends/cufft/execute_helper.hpp
+++ b/src/dft/backends/cufft/execute_helper.hpp
@@ -36,7 +36,7 @@
 
 namespace oneapi::math::dft::cufft::detail {
 
-#ifdef __ADAPTIVECPP__
+#if defined(__ADAPTIVECPP__) || defined (__HIPSYCL__)
 constexpr auto sycl_cuda_backend{ sycl::backend::cuda };
 #else // DPC++
 constexpr auto sycl_cuda_backend{ sycl::backend::ext_oneapi_cuda };

--- a/src/dft/backends/cufft/execute_helper.hpp
+++ b/src/dft/backends/cufft/execute_helper.hpp
@@ -37,9 +37,9 @@
 namespace oneapi::math::dft::cufft::detail {
 
 #ifdef __ADAPTIVECPP__
-constexpr auto sycl_cuda_backend{sycl::backend::cuda};
+constexpr auto sycl_cuda_backend{ sycl::backend::cuda };
 #else // DPC++
-constexpr auto sycl_cuda_backend{sycl::backend::ext_oneapi_cuda};
+constexpr auto sycl_cuda_backend{ sycl::backend::ext_oneapi_cuda };
 #endif
 
 template <dft::precision prec, dft::domain dom>

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -124,14 +124,14 @@ ONEMATH_EXPORT void compute_forward(descriptor_type& desc,
         dft::detail::fft_enqueue_task(cgh, [=](sycl::interop_handle ih) {
             auto stream = detail::setup_stream(func_name, ih, plan);
 
-            auto in_native = reinterpret_cast<void*>(
-                reinterpret_cast<fwd<descriptor_type>*>(
-                    ih.get_native_mem<detail::sycl_cuda_backend>(in_acc)) +
-                offsets[0]);
-            auto out_native = reinterpret_cast<void*>(
-                reinterpret_cast<bwd<descriptor_type>*>(
-                    ih.get_native_mem<detail::sycl_cuda_backend>(out_acc)) +
-                offsets[1]);
+            auto in_native =
+                reinterpret_cast<void*>(reinterpret_cast<fwd<descriptor_type>*>(
+                                            ih.get_native_mem<detail::sycl_cuda_backend>(in_acc)) +
+                                        offsets[0]);
+            auto out_native =
+                reinterpret_cast<void*>(reinterpret_cast<bwd<descriptor_type>*>(
+                                            ih.get_native_mem<detail::sycl_cuda_backend>(out_acc)) +
+                                        offsets[1]);
             detail::cufft_execute<detail::Direction::Forward, fwd<descriptor_type>>(
                 func_name, stream, plan, in_native, out_native);
         });

--- a/src/dft/backends/cufft/forward.cpp
+++ b/src/dft/backends/cufft/forward.cpp
@@ -79,7 +79,7 @@ ONEMATH_EXPORT void compute_forward(descriptor_type& desc,
             auto stream = detail::setup_stream(func_name, ih, plan);
 
             auto inout_native = reinterpret_cast<fwd<descriptor_type>*>(
-                ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(inout_acc));
+                ih.get_native_mem<detail::sycl_cuda_backend>(inout_acc));
             detail::cufft_execute<detail::Direction::Forward, fwd<descriptor_type>>(
                 func_name, stream, plan, reinterpret_cast<void*>(inout_native + offsets[0]),
                 reinterpret_cast<void*>(inout_native + offsets[1]));
@@ -126,11 +126,11 @@ ONEMATH_EXPORT void compute_forward(descriptor_type& desc,
 
             auto in_native = reinterpret_cast<void*>(
                 reinterpret_cast<fwd<descriptor_type>*>(
-                    ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(in_acc)) +
+                    ih.get_native_mem<detail::sycl_cuda_backend>(in_acc)) +
                 offsets[0]);
             auto out_native = reinterpret_cast<void*>(
                 reinterpret_cast<bwd<descriptor_type>*>(
-                    ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(out_acc)) +
+                    ih.get_native_mem<detail::sycl_cuda_backend>(out_acc)) +
                 offsets[1]);
             detail::cufft_execute<detail::Direction::Forward, fwd<descriptor_type>>(
                 func_name, stream, plan, in_native, out_native);

--- a/src/dft/backends/rocfft/commit.cpp
+++ b/src/dft/backends/rocfft/commit.cpp
@@ -34,6 +34,8 @@
 #include "oneapi/math/dft/detail/rocfft/onemath_dft_rocfft.hpp"
 #include "oneapi/math/dft/types.hpp"
 
+#include "execute_helper.hpp"
+#include "../../execute_helper_generic.hpp"
 #include "../stride_helper.hpp"
 
 #include "rocfft_handle.hpp"
@@ -557,9 +559,9 @@ public:
         this->get_queue().submit([&](sycl::handler& cgh) {
             auto workspace_acc =
                 buffer_workspace.template get_access<sycl::access::mode::read_write>(cgh);
-            cgh.host_task([=](sycl::interop_handle ih) {
+            dft::detail::fft_enqueue_task(cgh, [=](sycl::interop_handle ih) {
                 auto workspace_native = reinterpret_cast<scalar_type*>(
-                    ih.get_native_mem<sycl::backend::ext_oneapi_hip>(workspace_acc));
+                    ih.get_native_mem<sycl_hip_backend>(workspace_acc));
                 set_workspace_impl(handle, workspace_native, workspace_bytes, "set_workspace");
             });
         });

--- a/src/dft/backends/rocfft/execute_helper.hpp
+++ b/src/dft/backends/rocfft/execute_helper.hpp
@@ -36,6 +36,12 @@
 
 namespace oneapi::math::dft::rocfft::detail {
 
+#ifdef __ADAPTIVECPP__
+constexpr auto sycl_hip_backend{sycl::backend::hip};
+#else // DPC++
+constexpr auto sycl_hip_backend{sycl::backend::ext_oneapi_hip};
+#endif
+
 template <dft::precision prec, dft::domain dom>
 inline dft::detail::commit_impl<prec, dom>* checked_get_commit(
     dft::detail::descriptor<prec, dom>& desc) {
@@ -60,12 +66,12 @@ inline auto expect_config(DescT& desc, const char* message) {
 
 template <typename Acc>
 inline void* native_mem(sycl::interop_handle& ih, Acc& buf) {
-    return ih.get_native_mem<sycl::backend::ext_oneapi_hip>(buf);
+    return ih.get_native_mem<sycl_hip_backend>(buf);
 }
 
 inline hipStream_t setup_stream(const std::string& func, sycl::interop_handle& ih,
                                 rocfft_execution_info info) {
-    auto stream = ih.get_native_queue<sycl::backend::ext_oneapi_hip>();
+    auto stream = ih.get_native_queue<sycl_hip_backend>();
     auto result = rocfft_execution_info_set_stream(info, stream);
     if (result != rocfft_status_success) {
         throw oneapi::math::exception(

--- a/src/dft/backends/rocfft/execute_helper.hpp
+++ b/src/dft/backends/rocfft/execute_helper.hpp
@@ -37,9 +37,9 @@
 namespace oneapi::math::dft::rocfft::detail {
 
 #ifdef __ADAPTIVECPP__
-constexpr auto sycl_hip_backend{sycl::backend::hip};
+constexpr auto sycl_hip_backend{ sycl::backend::hip };
 #else // DPC++
-constexpr auto sycl_hip_backend{sycl::backend::ext_oneapi_hip};
+constexpr auto sycl_hip_backend{ sycl::backend::ext_oneapi_hip };
 #endif
 
 template <dft::precision prec, dft::domain dom>

--- a/src/dft/backends/rocfft/execute_helper.hpp
+++ b/src/dft/backends/rocfft/execute_helper.hpp
@@ -36,7 +36,7 @@
 
 namespace oneapi::math::dft::rocfft::detail {
 
-#ifdef __ADAPTIVECPP__
+#if defined(__ADAPTIVECPP__) || defined (__HIPSYCL__)
 constexpr auto sycl_hip_backend{ sycl::backend::hip };
 #else // DPC++
 constexpr auto sycl_hip_backend{ sycl::backend::ext_oneapi_hip };

--- a/src/dft/backends/rocfft/execute_helper.hpp
+++ b/src/dft/backends/rocfft/execute_helper.hpp
@@ -36,7 +36,7 @@
 
 namespace oneapi::math::dft::rocfft::detail {
 
-#if defined(__ADAPTIVECPP__) || defined (__HIPSYCL__)
+#if defined(__ADAPTIVECPP__) || defined(__HIPSYCL__)
 constexpr auto sycl_hip_backend{ sycl::backend::hip };
 #else // DPC++
 constexpr auto sycl_hip_backend{ sycl::backend::ext_oneapi_hip };

--- a/src/dft/execute_helper_generic.hpp
+++ b/src/dft/execute_helper_generic.hpp
@@ -41,6 +41,8 @@ template <typename HandlerT, typename FnT>
 static inline void fft_enqueue_task(HandlerT&& cgh, FnT&& f) {
 #if defined(__ADAPTIVECPP__)
     cgh.AdaptiveCpp_enqueue_custom_operation([=](sycl::interop_handle ih) {
+#elif defined(__HIPSYCL__)
+    cgh.hipSYCL_enqueue_custom_operation([=](sycl::interop_handle ih) {
 #elif defined(SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND)
     cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 #else

--- a/src/dft/execute_helper_generic.hpp
+++ b/src/dft/execute_helper_generic.hpp
@@ -39,7 +39,9 @@ namespace oneapi::math::dft::detail {
  */
 template <typename HandlerT, typename FnT>
 static inline void fft_enqueue_task(HandlerT&& cgh, FnT&& f) {
-#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+#if defined(__ADAPTIVECPP__)
+    cgh.AdaptiveCpp_enqueue_custom_operation([=](sycl::interop_handle ih) {
+#elif defined(SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND)
     cgh.ext_codeplay_enqueue_native_command([=](sycl::interop_handle ih) {
 #else
     cgh.host_task([=](sycl::interop_handle ih) {

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -571,7 +571,9 @@ inline void recommit_values(sycl::queue& sycl_queue) {
 }
 
 template <oneapi::math::dft::precision precision, oneapi::math::dft::domain domain>
-inline void change_queue_causes_wait(sycl::queue& busy_queue) {
+inline void change_queue_causes_wait([[maybe_unused]] sycl::queue& busy_queue) {
+    // Skip this test in AdaptiveCpp, which doesn't support host_task
+    #ifndef __ADAPTIVECPP__
     // create a queue with work on it, and then show that work is waited on when the descriptor
     // is committed to a new queue.
     // its possible to have a false positive result, but a false negative should not be possible.
@@ -616,6 +618,7 @@ inline void change_queue_causes_wait(sycl::queue& busy_queue) {
     // busy queue task has now completed.
     auto after_status = e.template get_info<sycl::info::event::command_execution_status>();
     ASSERT_EQ(after_status, sycl::info::event_command_status::complete);
+    #endif
 }
 
 template <oneapi::math::dft::precision precision, oneapi::math::dft::domain domain>

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -572,8 +572,8 @@ inline void recommit_values(sycl::queue& sycl_queue) {
 
 template <oneapi::math::dft::precision precision, oneapi::math::dft::domain domain>
 inline void change_queue_causes_wait([[maybe_unused]] sycl::queue& busy_queue) {
-    // Skip this test in AdaptiveCpp, which doesn't support host_task
-    #ifndef __ADAPTIVECPP__
+// Skip this test in AdaptiveCpp, which doesn't support host_task
+#ifndef __ADAPTIVECPP__
     // create a queue with work on it, and then show that work is waited on when the descriptor
     // is committed to a new queue.
     // its possible to have a false positive result, but a false negative should not be possible.
@@ -618,7 +618,7 @@ inline void change_queue_causes_wait([[maybe_unused]] sycl::queue& busy_queue) {
     // busy queue task has now completed.
     auto after_status = e.template get_info<sycl::info::event::command_execution_status>();
     ASSERT_EQ(after_status, sycl::info::event_command_status::complete);
-    #endif
+#endif
 }
 
 template <oneapi::math::dft::precision precision, oneapi::math::dft::domain domain>

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -573,7 +573,7 @@ inline void recommit_values(sycl::queue& sycl_queue) {
 template <oneapi::math::dft::precision precision, oneapi::math::dft::domain domain>
 inline void change_queue_causes_wait([[maybe_unused]] sycl::queue& busy_queue) {
 // Skip this test in AdaptiveCpp, which doesn't support host_task
-#if !defined(__ADAPTIVECPP__) && !defined (__HIPSYCL__)
+#if !defined(__ADAPTIVECPP__) && !defined(__HIPSYCL__)
     // create a queue with work on it, and then show that work is waited on when the descriptor
     // is committed to a new queue.
     // its possible to have a false positive result, but a false negative should not be possible.

--- a/tests/unit_tests/dft/source/descriptor_tests.cpp
+++ b/tests/unit_tests/dft/source/descriptor_tests.cpp
@@ -573,7 +573,7 @@ inline void recommit_values(sycl::queue& sycl_queue) {
 template <oneapi::math::dft::precision precision, oneapi::math::dft::domain domain>
 inline void change_queue_causes_wait([[maybe_unused]] sycl::queue& busy_queue) {
 // Skip this test in AdaptiveCpp, which doesn't support host_task
-#ifndef __ADAPTIVECPP__
+#if !defined(__ADAPTIVECPP__) && !defined (__HIPSYCL__)
     // create a queue with work on it, and then show that work is waited on when the descriptor
     // is committed to a new queue.
     // its possible to have a false positive result, but a false negative should not be possible.


### PR DESCRIPTION
# Description
Ensure the cuFFT and rocFFT backends compile and run with AdaptiveCpp. The changes required are minimal and come from:
* different names of backend enum values between the compilers (e.g. `ext_oneapi_cuda` vs `cuda`)
* different names of the native command extension
* no `host_task` in AdaptiveCpp

# Checklist
- [x] Do all unit tests pass locally? Attach a log.
  - cuFFT, DPC++, NVIDIA RTX 3060
    - [ut-dpcpp-cuda-rtx3060.log.gz](https://github.com/user-attachments/files/19893837/ut-dpcpp-cuda-rtx3060.log.gz)
    - total 1879, skipped 1072, ran 807, passed 807, failed 0
  - cuFFT, AdaptiveCpp, NVIDIA RTX 3060
    - [ut-acpp-cuda-rtx3060.log.gz](https://github.com/user-attachments/files/19893839/ut-acpp-cuda-rtx3060.log.gz)
    - total 1879, skipped 1072, ran 807, passed 807, failed 0
  - rocFFT, DPC++, AMD MI210
    - [ut-dpcpp-hip-mi210.log.gz](https://github.com/user-attachments/files/19893842/ut-dpcpp-hip-mi210.log.gz)
    - total 1879, skipped 544, ran 1335, passed 1327, failed 8
  - rocFFT, AdaptiveCpp, AMD MI210
    - [ut-acpp-hip-mi210.log.gz](https://github.com/user-attachments/files/19893849/ut-acpp-hip-mi210.log.gz)
    - total 1879, skipped 544, ran 1335, passed 1327, failed 8

- [x] Have you added relevant regression tests? Not needed - existing unit tests cover all the features and work with AdaptiveCpp.
- [x] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)? Compile with `-DENABLE_MKLCPU_BACKEND=False -DENABLE_MKLGPU_BACKEND=False -DENABLE_CUFFT_BACKEND=True -DBUILD_FUNCTIONAL_TESTS=True -DBUILD_EXAMPLES=True -DONEMATH_SYCL_IMPLEMENTATION=hipsycl -DHIPSYCL_TARGETS=generic -DCMAKE_CXX_COMPILER=acpp`
