### PR TITLE
[Docs] Introduce backend maintainer roles

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -37,6 +37,13 @@
 /include/oneapi/math/blas.hxx @uxlfoundation/onemath-blas-write
 /include/oneapi/math/bfloat16.hpp @uxlfoundation/onemath-blas-write
 /include/oneapi/mkl/blas.hpp @uxlfoundation/onemath-blas-write
+/src/blas/backends/armpl/ @uxlfoundation/onemath-cpu-aarch64 @uxlfoundation/onemath-blas-write
+/src/blas/backends/cublas/ @uxlfoundation/onemath-gpu-nvidia @uxlfoundation/onemath-blas-write
+/src/blas/backends/mkl_common/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-blas-write
+/src/blas/backends/mklcpu/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-blas-write
+/src/blas/backends/mklgpu/ @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-blas-write
+/src/blas/backends/netlib/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-blas-write
+/src/blas/backends/rocblas/ @uxlfoundation/onemath-gpu-amd @uxlfoundation/onemath-blas-write
 /src/blas/ @uxlfoundation/onemath-blas-write
 /tests/unit_tests/blas/ @uxlfoundation/onemath-blas-write
 
@@ -45,6 +52,10 @@
 /include/oneapi/math/dft/ @uxlfoundation/onemath-dft-write
 /include/oneapi/math/dft.hpp @uxlfoundation/onemath-dft-write
 /include/oneapi/mkl/dft.hpp @uxlfoundation/onemath-dft-write
+/src/dft/backends/cufft/ @uxlfoundation/onemath-gpu-nvidia @uxlfoundation/onemath-dft-write
+/src/dft/backends/mklcpu/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-dft-write
+/src/dft/backends/mklgpu/ @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-dft-write
+/src/dft/backends/rocfft/ @uxlfoundation/onemath-gpu-amd @uxlfoundation/onemath-dft-write
 /src/dft/ @uxlfoundation/onemath-dft-write
 /tests/unit_tests/dft/ @uxlfoundation/onemath-dft-write
 
@@ -53,6 +64,12 @@
 /include/oneapi/math/lapack/ @uxlfoundation/onemath-lapack-write
 /include/oneapi/math/lapack.hpp @uxlfoundation/onemath-lapack-write
 /include/oneapi/mkl/lapack.hpp @uxlfoundation/onemath-lapack-write
+/src/lapack/backends/armpl/ @uxlfoundation/onemath-cpu-aarch64 @uxlfoundation/onemath-lapack-write
+/src/lapack/backends/cusolver/ @uxlfoundation/onemath-gpu-nvidia @uxlfoundation/onemath-lapack-write
+/src/lapack/backends/mkl_common/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-lapack-write
+/src/lapack/backends/mklcpu/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-lapack-write
+/src/lapack/backends/mklgpu/ @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-lapack-write
+/src/lapack/backends/rocsolver/ @uxlfoundation/onemath-gpu-amd @uxlfoundation/onemath-lapack-write
 /src/lapack/ @uxlfoundation/onemath-lapack-write
 /tests/unit_tests/lapack/ @uxlfoundation/onemath-lapack-write
 
@@ -62,6 +79,11 @@
 /include/oneapi/math/rng.hpp @uxlfoundation/onemath-rng-write
 /include/oneapi/mkl/rng.hpp @uxlfoundation/onemath-rng-write
 /include/oneapi/mkl/rng/device.hpp @uxlfoundation/onemath-rng-write
+/src/rng/backends/armpl/ @uxlfoundation/onemath-cpu-aarch64 @uxlfoundation/onemath-rng-write
+/src/rng/backends/curand/ @uxlfoundation/onemath-gpu-nvidia @uxlfoundation/onemath-rng-write
+/src/rng/backends/mklcpu/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-rng-write
+/src/rng/backends/mklgpu/ @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-rng-write
+/src/rng/backends/rocrand/ @uxlfoundation/onemath-gpu-amd @uxlfoundation/onemath-rng-write
 /src/rng/ @uxlfoundation/onemath-rng-write
 /tests/unit_tests/rng/ @uxlfoundation/onemath-rng-write
 
@@ -70,6 +92,11 @@
 /include/oneapi/math/sparse_blas/ @uxlfoundation/onemath-sparse-write
 /include/oneapi/math/sparse_blas.hpp @uxlfoundation/onemath-sparse-write
 /include/oneapi/mkl/sparse_blas.hpp @uxlfoundation/onemath-sparse-write
+/src/sparse_blas/backends/cusparse/ @uxlfoundation/onemath-gpu-nvidia @uxlfoundation/onemath-sparse-write
+/src/sparse_blas/backends/mkl_common/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-sparse-write
+/src/sparse_blas/backends/mklcpu/ @uxlfoundation/onemath-cpu-x64 @uxlfoundation/onemath-sparse-write
+/src/sparse_blas/backends/mklgpu/ @uxlfoundation/onemath-gpu-intel @uxlfoundation/onemath-sparse-write
+/src/sparse_blas/backends/rocsparse/ @uxlfoundation/onemath-gpu-amd @uxlfoundation/onemath-sparse-write
 /src/sparse_blas/ @uxlfoundation/onemath-sparse-write
 /tests/unit_tests/sparse_blas/ @uxlfoundation/onemath-sparse-write
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -72,6 +72,11 @@ For GitHub questions, issues, RFCs, or PRs you can contact maintainers via one o
 | @uxlfoundation/onemath-rng-write | oneMath RNG maintainers |
 | @uxlfoundation/onemath-sparse-write | oneMath Sparse Algebra maintainers |
 | @uxlfoundation/onemath-vm-write | oneMath Vector Math maintainers |
+| @uxlfoundation/onemath-cpu-aarch64 | AArch64 CPU maintainers |
+| @uxlfoundation/onemath-cpu-x64 | x86 CPU maintainers |
+| @uxlfoundation/onemath-gpu-amd | AMD GPU maintainers |
+| @uxlfoundation/onemath-gpu-intel | Intel GPU maintainers |
+| @uxlfoundation/onemath-gpu-nvidia | NVIDIA GPU maintainers |
 
 Please read [MAINTAINERS page](MAINTAINERS.md) for more information about maintainer roles, responsibilities, and how to become one of them.
 

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -101,7 +101,6 @@ Responsibilities:
 
 Requirements:
   * Experience as Contributor in the specific backend for at least 6 months.
-  * Commit at least 25% of working time to the project.
   * Track record of accepted code contributions to a specific backend.
   * Track record of contributions to the code review process.
   * Demonstrated in-depth knowledge of the specific backend.

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,9 +4,10 @@ This document defines roles in oneMath project.
 
 # Roles and responsibilities
 
-oneMath project defines three main roles:
+oneMath project defines four main roles:
  * [Contributor](#contributor)
  * [Domain maintainer](#domain-maintainer)
+ * [Backend maintainer](#backend-maintainer)
  * [Architecture maintainer](#architecture-maintainer)
 
 These roles are merit based. Refer to the corresponding section for specific
@@ -44,7 +45,7 @@ Responsibilities:
   * Follow and enforce the project [contributing guidelines](CONTRIBUTING.md).
   * Co-own with other domain maintainers a specific domain, including contributing
     bug fixes, implementing features, and answering domain specific questions
-    in [#onemkl](https://uxlfoundation.slack.com/archives/onemkl) Slack channel.
+    in [#onemath](https://uxlfoundation.slack.com/archives/onemath) Slack channel.
   * Review pull requests in their specific domain.
   * Monitor testing results and flag issues in their specific areas of
     responsibility.
@@ -66,7 +67,7 @@ Privileges:
 
 The process of becoming a Domain maintainer is:
 1. A Contributor requests to join corresponding Domain maintainer GitHub team.
-2. At least one specific Domain maintainers approve the request.
+2. At least one specific Domain maintainer approves the request.
 
 ### List of GitHub teams for Domain maintainers
 
@@ -79,6 +80,53 @@ The process of becoming a Domain maintainer is:
 | @uxlfoundation/onemath-sparse-write | oneMath Sparse Algebra maintainers |
 | @uxlfoundation/onemath-vm-write | oneMath Vector Math maintainers |
 
+## Backend Maintainer
+
+Backend maintainer has responsibility for a specific backend in the project.
+Backend maintainers are collectively responsible for developing and maintaining their backends,
+including reviewing certain changes to their backend and indicating
+whether those changes are ready to merge. They have a track record of
+contribution and review in the project.
+
+Responsibilities:
+  * Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
+  * Follow and enforce the project [contributing guidelines](CONTRIBUTING.md).
+  * Co-own with other backend maintainers a specific backend, including contributing
+    bug fixes, implementing features, and answering backend specific questions
+    in [#onemath](https://uxlfoundation.slack.com/archives/onemath) Slack channel.
+  * Review pull requests pertaining to their specific backend.
+  * Monitor testing results and flag issues in their specific areas of
+    responsibility.
+  * Support and guide Contributors.
+
+Requirements:
+  * Experience as Contributor in the specific backend for at least 6 months.
+  * Commit at least 25% of working time to the project.
+  * Track record of accepted code contributions to a specific backend.
+  * Track record of contributions to the code review process.
+  * Demonstrated in-depth knowledge of the specific backend.
+  * Commits to being responsible for that specific backend.
+
+Privileges:
+  * PR approval counts towards approval requirements for a specific backend.
+  * Can promote fully approved Pull Requests to the `develop` branch.
+  * Can recommend Contributors to become Backend maintainers.
+  * Eligible to become an Architecture maintainer.
+
+The process of becoming a Backend maintainer is:
+1. A Contributor requests to join corresponding Backend maintainer GitHub team.
+2. At least one specific Backend maintainer approves the request.
+
+### List of GitHub teams for Backend maintainers
+
+| GitHub team name | Backend maintainers |
+:-----------|:------------|
+| @uxlfoundation/onemath-cpu-aarch64 | AArch64 CPU maintainers |
+| @uxlfoundation/onemath-cpu-x64 | x86 CPU maintainers |
+| @uxlfoundation/onemath-gpu-amd | AMD GPU maintainers |
+| @uxlfoundation/onemath-gpu-intel | Intel GPU maintainers |
+| @uxlfoundation/onemath-gpu-nvidia | NVIDIA GPU maintainers |
+
 ## Architecture Maintainer
 Architecture maintainers are the most established contributors who are responsible for the
 project technical direction and participate in making decisions about the
@@ -88,26 +136,27 @@ Responsibilities:
   * Follow the [Code of Conduct](CODE_OF_CONDUCT.md).
   * Follow and enforce the project [contributing guidelines](CONTRIBUTING.md)
   * Co-own with other Domain maintainers on the technical direction of a specific domain.
+  * Co-own with other Backend maintainers on the support and implementation of a specific backend.
   * Co-own with other Architecture maintainers on the project as a whole, including
-determining strategy and policy for the project.
-  * Support and guide Contributors and Domain maintainers.
+    determining strategy and policy for the project.
+  * Support and guide Contributors, Domain maintainers, and Backend maintainers.
 
 Requirements:
-  * Experience as a Domain maintainer or Contributor with focus on the project architecture
-for at least 12 months.
+  * Experience as a Domain or Backend maintainer or Contributor with focus on the project
+    architecture for at least 12 months.
   * Commit at least 25% of working time to the project.
   * Track record of major project contributions.
   * Demonstrated deep knowledge of the project architecture and build.
-  * Demonstrated broad knowledge of the project across multiple domains.
+  * Demonstrated broad knowledge of the project across multiple domains and/or multiple backends.
   * Is able to exercise judgment for the good of the project, independent of
     their employer, friends, or team.
 
 Privileges:
   * Can represent the project in public as a Maintainer.
-  * Can recommend Contributor or Domain maintainer to become Architecture maintainers.
+  * Can recommend Contributor, Domain maintainer, or Backend maintainer to become Architecture maintainer.
 
 Process of becoming a maintainer:
-1. A Contributor or Domain maintainer requests to join oneMath Architecture maintainers GitHub team
-(@uxlfoundation/onemath-arch-write).
-2. At least one of Architecture maintainers approves the request.
+1. A Contributor, Domain maintainer, or Backend maintainer requests to join oneMath Architecture
+   maintainers GitHub team (@uxlfoundation/onemath-arch-write).
+2. At least one of the existing Architecture maintainers approves the request.
 


### PR DESCRIPTION
# Description

Related RFC: #673 

Updates the CONTRIBUTING.md and MAINTAINERS.md files to introduce the new backend maintainer roles as described in the corresponding RFC, as well as CODEOWNERS file. These roles were created based on the approved RFC:

@uxlfoundation/onemath-cpu-aarch64
@uxlfoundation/onemath-cpu-x64
@uxlfoundation/onemath-gpu-amd
@uxlfoundation/onemath-gpu-intel
@uxlfoundation/onemath-gpu-nvidia