### PR TITLE
[Docs] Fix typo in documentation on building and running tests

### DIFF
--- a/docs/building_and_running_tests.rst
+++ b/docs/building_and_running_tests.rst
@@ -28,7 +28,7 @@ following:
   cmake -DCMAKE_INSTALL_PREFIX=~/lapack -DCBLAS=True -DLAPACK=True -DLAPACKE=True -DBUILD_INDEX64=False -DBUILD_SHARED_LIBS=True ..
   cmake --build . -j --target install
 
-and then used in oneMath by setting ``-REF_BLAS_ROOT=/path/to/lapack/install``
+and then used in oneMath by setting ``-DREF_BLAS_ROOT=/path/to/lapack/install``
 and ``-DREF_LAPACK_ROOT=/path/to/lapack/install``.
 
 You can re-run tests without re-building the entire project.


### PR DESCRIPTION
The CMake configure option for `REF_BLAS_ROOT` needs a `-D` prefix on the command-line.