### PR TITLE
[BLAS] Remove queue from `host_task_internal` API

### DIFF
--- a/src/blas/backends/cublas/cublas_batch.cpp
+++ b/src/blas/backends/cublas/cublas_batch.cpp
@@ -161,8 +161,8 @@ inline void gemm_batch_impl(sycl::queue& queue, transpose transa, transpose tran
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuTypeA*>(a_acc);
             auto b_ = sc.get_mem<cuTypeB*>(b_acc);
             auto c_ = sc.get_mem<cuTypeC*>(c_acc);
@@ -514,8 +514,8 @@ inline sycl::event gemv_batch(const char* func_name, Func func, sycl::queue& que
     }
     auto done = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(dependencies);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             int64_t offset = 0;
             cublasStatus_t err;
             auto** a_ = reinterpret_cast<const cuDataType**>(a);
@@ -632,8 +632,8 @@ inline sycl::event gemm_batch_strided_usm_impl(sycl::queue& queue, transpose tra
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             cublasStatus_t err;
 #ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
             CUBLAS_ERROR_FUNC_T("cublasGemmStridedBatchedEx", cublasGemmStridedBatchedEx, err,
@@ -718,8 +718,8 @@ inline sycl::event gemm_batch_usm_impl(sycl::queue& queue, transpose* transa, tr
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             int64_t offset = 0;
             cublasStatus_t err;
             for (int64_t i = 0; i < group_count; i++) {
@@ -832,8 +832,8 @@ inline sycl::event trsm_batch(const char* func_name, Func func, sycl::queue& que
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             int64_t offset = 0;
             cublasStatus_t err;
             for (int64_t i = 0; i < group_count; i++) {

--- a/src/blas/backends/cublas/cublas_extensions.cpp
+++ b/src/blas/backends/cublas/cublas_extensions.cpp
@@ -96,8 +96,8 @@ void omatcopy(const char* func_name, Func func, sycl::queue& queue, transpose tr
         auto b_acc = b.template get_access<sycl::access::mode::read_write>(cgh);
         const int64_t logical_m = (trans == oneapi::math::transpose::nontrans ? m : n);
         const int64_t logical_n = (trans == oneapi::math::transpose::nontrans ? n : m);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             cublasStatus_t err;
@@ -172,8 +172,8 @@ void omatadd(const char* func_name, Func func, sycl::queue& queue, transpose tra
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -274,8 +274,8 @@ sycl::event omatcopy(const char* func_name, Func func, sycl::queue& queue, trans
         cgh.depends_on(dependencies);
         const int64_t logical_m = (trans == oneapi::math::transpose::nontrans ? m : n);
         const int64_t logical_n = (trans == oneapi::math::transpose::nontrans ? n : m);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<cuDataType*>(b);
             cublasStatus_t err;
@@ -356,8 +356,8 @@ inline sycl::event omatadd(const char* func_name, Func func, sycl::queue& queue,
     overflow_check(m, n, lda, ldb, ldc);
     auto done = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(dependencies);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);
@@ -459,8 +459,8 @@ void omatcopy(const char* func_name, Func func, sycl::queue& queue, transpose tr
         auto b_acc = b.template get_access<sycl::access::mode::read_write>(cgh);
         const int64_t logical_m = (trans == oneapi::math::transpose::nontrans ? n : m);
         const int64_t logical_n = (trans == oneapi::math::transpose::nontrans ? m : n);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             cublasStatus_t err;
@@ -535,8 +535,8 @@ void omatadd(const char* func_name, Func func, sycl::queue& queue, transpose tra
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -637,8 +637,8 @@ sycl::event omatcopy(const char* func_name, Func func, sycl::queue& queue, trans
         cgh.depends_on(dependencies);
         const int64_t logical_m = (trans == oneapi::math::transpose::nontrans ? n : m);
         const int64_t logical_n = (trans == oneapi::math::transpose::nontrans ? m : n);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<cuDataType*>(b);
             cublasStatus_t err;
@@ -719,8 +719,8 @@ inline sycl::event omatadd(const char* func_name, Func func, sycl::queue& queue,
     overflow_check(m, n, lda, ldb, ldc);
     auto done = queue.submit([&](sycl::handler& cgh) {
         cgh.depends_on(dependencies);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);

--- a/src/blas/backends/cublas/cublas_level1.cpp
+++ b/src/blas/backends/cublas/cublas_level1.cpp
@@ -41,8 +41,8 @@ inline void asum(const char* func_name, Func func, sycl::queue& queue, int64_t n
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -81,8 +81,8 @@ inline void scal(const char* func_name, Func func, sycl::queue& queue, int64_t n
     overflow_check(n, incx);
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = sc.get_mem<cuDataType2*>(x_acc);
             cublasStatus_t err;
             // SCAL does not support negative incx
@@ -112,8 +112,8 @@ inline void axpy(const char* func_name, Func func, sycl::queue& queue, int64_t n
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
             cublasStatus_t err;
@@ -167,8 +167,8 @@ inline void rotg(const char* func_name, Func func, sycl::queue& queue, sycl::buf
         auto b_acc = b.template get_access<sycl::access::mode::read_write>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
         auto s_acc = s.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -211,8 +211,8 @@ inline void rotm(const char* func_name, Func func, sycl::queue& queue, int64_t n
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
         auto param_acc = param.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -250,8 +250,8 @@ inline void copy(const char* func_name, Func func, sycl::queue& queue, int64_t n
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
             cublasStatus_t err;
@@ -282,8 +282,8 @@ inline void dot(const char* func_name, Func func, sycl::queue& queue, int64_t n,
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
         auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -327,8 +327,8 @@ inline void rot(const char* func_name, Func func, sycl::queue& queue, int64_t n,
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -364,8 +364,8 @@ void sdsdot(sycl::queue& queue, int64_t n, float sb, sycl::buffer<float, 1>& x, 
         auto x_acc = x.get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.get_access<sycl::access::mode::read>(cgh);
         auto res_acc = result.get_access<sycl::access::mode::write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -404,8 +404,8 @@ inline void rotmg(const char* func_name, Func func, sycl::queue& queue, sycl::bu
         auto x1_acc = x1.template get_access<sycl::access::mode::read_write>(cgh);
         auto y1_acc = y1_buff.template get_access<sycl::access::mode::read>(cgh);
         auto param_acc = param.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -454,8 +454,8 @@ inline void iamax(const char* func_name, Func func, sycl::queue& queue, int64_t 
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -505,8 +505,8 @@ inline void swap(const char* func_name, Func func, sycl::queue& queue, int64_t n
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
             cublasStatus_t err;
@@ -544,8 +544,8 @@ inline void iamin(const char* func_name, Func func, sycl::queue& queue, int64_t 
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto int_res_acc = int_res_buff.template get_access<sycl::access::mode::write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -597,8 +597,8 @@ inline void nrm2(const char* func_name, Func func, sycl::queue& queue, int64_t n
     queue.submit([&](sycl::handler& cgh) {
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             // By default the pointer mode is the CUBLAS_POINTER_MODE_HOST
             // when the data is on buffer, it must be set to
             // CUBLAS_POINTER_MODE_DEVICE mode otherwise it causes the segmentation
@@ -647,8 +647,8 @@ inline sycl::event asum(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType1*>(x);
             auto res_ = reinterpret_cast<cuDataType2*>(result);
             if (result_on_device) {
@@ -687,8 +687,8 @@ inline sycl::event scal(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<cuDataType2*>(x);
             cublasStatus_t err;
             // SCAL does not support negative incx
@@ -723,8 +723,8 @@ inline sycl::event axpy(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
             cublasStatus_t err;
@@ -796,8 +796,8 @@ inline sycl::event rotg(const char* func_name, Func func, sycl::queue& queue, T1
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType1*>(a);
             auto b_ = reinterpret_cast<cuDataType1*>(b);
             auto c_ = reinterpret_cast<cuDataType2*>(c);
@@ -838,8 +838,8 @@ inline sycl::event rotm(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
             auto param_ = reinterpret_cast<cuDataType*>(param);
@@ -872,8 +872,8 @@ inline sycl::event copy(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
             cublasStatus_t err;
@@ -908,8 +908,8 @@ inline sycl::event dot(const char* func_name, Func func, sycl::queue& queue, int
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<const cuDataType*>(y);
             auto res_ = reinterpret_cast<cuDataType*>(result);
@@ -954,8 +954,8 @@ inline sycl::event rot(const char* func_name, Func func, sycl::queue& queue, int
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<cuDataType1*>(x);
             auto y_ = reinterpret_cast<cuDataType1*>(y);
             cublasStatus_t err;
@@ -992,8 +992,8 @@ sycl::event sdsdot(sycl::queue& queue, int64_t n, float sb, const float* x, int6
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const float*>(x);
             auto y_ = reinterpret_cast<const float*>(y);
             auto res_ = reinterpret_cast<float*>(result);
@@ -1057,8 +1057,8 @@ inline sycl::event rotmg(const char* func_name, Func func, sycl::queue& queue, T
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto d1_ = reinterpret_cast<cuDataType*>(d1);
             auto d2_ = reinterpret_cast<cuDataType*>(d2);
             auto x1_ = reinterpret_cast<cuDataType*>(x1);
@@ -1120,8 +1120,8 @@ inline sycl::event iamax(const char* func_name, Func func, sycl::queue& queue, i
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             if (result_on_device) {
                 cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
@@ -1180,8 +1180,8 @@ inline sycl::event swap(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
             cublasStatus_t err;
@@ -1230,8 +1230,8 @@ inline sycl::event iamin(const char* func_name, Func func, sycl::queue& queue, i
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             if (result_on_device) {
                 cublasSetPointerMode(handle, CUBLAS_POINTER_MODE_DEVICE);
@@ -1294,8 +1294,8 @@ inline sycl::event nrm2(const char* func_name, Func func, sycl::queue& queue, in
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto x_ = reinterpret_cast<const cuDataType1*>(x);
             auto res_ = reinterpret_cast<cuDataType2*>(result);
             if (result_on_device) {

--- a/src/blas/backends/cublas/cublas_level2.cpp
+++ b/src/blas/backends/cublas/cublas_level2.cpp
@@ -40,8 +40,8 @@ inline void gemv(const char* func_name, Func func, sycl::queue& queue, transpose
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -77,8 +77,8 @@ inline void gbmv(const char* func_name, Func func, sycl::queue& queue, transpose
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -114,8 +114,8 @@ inline void ger(const char* func_name, Func func, sycl::queue& queue, int64_t m,
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -151,8 +151,8 @@ inline void hbmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -186,8 +186,8 @@ inline void hemv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -222,8 +222,8 @@ inline void her(const char* func_name, Func func, sycl::queue& queue, uplo upper
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -256,8 +256,8 @@ inline void her2(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -292,8 +292,8 @@ inline void hpmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -328,8 +328,8 @@ inline void hpr(const char* func_name, Func func, sycl::queue& queue, uplo upper
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -361,8 +361,8 @@ inline void hpr2(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -396,8 +396,8 @@ inline void sbmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -432,8 +432,8 @@ inline void symv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -466,8 +466,8 @@ inline void syr(const char* func_name, Func func, sycl::queue& queue, uplo upper
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -501,8 +501,8 @@ inline void syr2(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -540,8 +540,8 @@ inline void spmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -574,8 +574,8 @@ inline void spr(const char* func_name, Func func, sycl::queue& queue, uplo upper
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -607,8 +607,8 @@ inline void spr2(const char* func_name, Func func, sycl::queue& queue, uplo uppe
         auto a_acc = a.template get_access<sycl::access::mode::read_write>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
         auto y_acc = y.template get_access<sycl::access::mode::read>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             auto y_ = sc.get_mem<cuDataType*>(y_acc);
@@ -641,8 +641,8 @@ inline void tbmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -677,8 +677,8 @@ inline void tbsv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -713,8 +713,8 @@ inline void tpmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -748,8 +748,8 @@ inline void tpsv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -783,8 +783,8 @@ inline void trmv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -818,8 +818,8 @@ inline void trsv(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto x_acc = x.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto x_ = sc.get_mem<cuDataType*>(x_acc);
             cublasStatus_t err;
@@ -858,8 +858,8 @@ inline sycl::event gemv(const char* func_name, Func func, sycl::queue& queue, tr
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -898,8 +898,8 @@ inline sycl::event gbmv(const char* func_name, Func func, sycl::queue& queue, tr
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -938,8 +938,8 @@ inline sycl::event ger(const char* func_name, Func func, sycl::queue& queue, int
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<const cuDataType*>(y);
@@ -979,8 +979,8 @@ inline sycl::event hbmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -1016,8 +1016,8 @@ inline sycl::event hemv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -1055,8 +1055,8 @@ inline sycl::event her(const char* func_name, Func func, sycl::queue& queue, upl
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             cublasStatus_t err;
@@ -1092,8 +1092,8 @@ inline sycl::event her2(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<const cuDataType*>(y);
@@ -1130,8 +1130,8 @@ inline sycl::event hpmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -1169,8 +1169,8 @@ inline sycl::event hpr(const char* func_name, Func func, sycl::queue& queue, upl
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             cublasStatus_t err;
@@ -1206,8 +1206,8 @@ inline sycl::event hpr2(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<const cuDataType*>(y);
@@ -1245,8 +1245,8 @@ inline sycl::event sbmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -1283,8 +1283,8 @@ inline sycl::event symv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -1321,8 +1321,8 @@ inline sycl::event syr(const char* func_name, Func func, sycl::queue& queue, upl
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             cublasStatus_t err;
@@ -1360,8 +1360,8 @@ inline sycl::event syr2(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<const cuDataType*>(y);
@@ -1401,8 +1401,8 @@ inline sycl::event spmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<cuDataType*>(y);
@@ -1439,8 +1439,8 @@ inline sycl::event spr(const char* func_name, Func func, sycl::queue& queue, upl
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             cublasStatus_t err;
@@ -1475,8 +1475,8 @@ inline sycl::event spr2(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<cuDataType*>(a);
             auto x_ = reinterpret_cast<const cuDataType*>(x);
             auto y_ = reinterpret_cast<const cuDataType*>(y);
@@ -1514,8 +1514,8 @@ inline sycl::event tbmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<cuDataType*>(x);
             cublasStatus_t err;
@@ -1554,8 +1554,8 @@ inline sycl::event tbsv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<cuDataType*>(x);
             cublasStatus_t err;
@@ -1593,8 +1593,8 @@ inline sycl::event tpmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<cuDataType*>(x);
             cublasStatus_t err;
@@ -1632,8 +1632,8 @@ inline sycl::event tpsv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<cuDataType*>(x);
             cublasStatus_t err;
@@ -1671,8 +1671,8 @@ inline sycl::event trmv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<cuDataType*>(x);
             cublasStatus_t err;
@@ -1710,8 +1710,8 @@ inline sycl::event trsv(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto x_ = reinterpret_cast<cuDataType*>(x);
             cublasStatus_t err;

--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -41,8 +41,8 @@ inline void gemm(const char* func_name, Func func, sycl::queue& queue, transpose
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -88,8 +88,8 @@ inline void gemm_ex(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C, sycl::que
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType_A*>(a_acc);
             auto b_ = sc.get_mem<cuDataType_B*>(b_acc);
             auto c_ = sc.get_mem<cuDataType_C*>(c_acc);
@@ -140,8 +140,8 @@ inline void symm(const char* func_name, Func func, sycl::queue& queue, side left
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -179,8 +179,8 @@ inline void hemm(const char* func_name, Func func, sycl::queue& queue, side left
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -213,8 +213,8 @@ inline void syrk(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
             cublasStatus_t err;
@@ -252,8 +252,8 @@ inline void herk(const char* func_name, Func func, sycl::queue& queue, uplo uppe
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
             cublasStatus_t err;
@@ -289,8 +289,8 @@ inline void syr2k(const char* func_name, Func func, sycl::queue& queue, uplo upp
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -329,8 +329,8 @@ inline void her2k(const char* func_name, Func func, sycl::queue& queue, uplo upp
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read>(cgh);
         auto c_acc = c.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             auto c_ = sc.get_mem<cuDataType*>(c_acc);
@@ -370,8 +370,8 @@ inline void trmm(const char* func_name, Func func, sycl::queue& queue, side left
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             cublasStatus_t err;
@@ -406,8 +406,8 @@ inline void trsm(const char* func_name, Func func, sycl::queue& queue, side left
     queue.submit([&](sycl::handler& cgh) {
         auto a_acc = a.template get_access<sycl::access::mode::read>(cgh);
         auto b_acc = b.template get_access<sycl::access::mode::read_write>(cgh);
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = sc.get_mem<cuDataType*>(a_acc);
             auto b_ = sc.get_mem<cuDataType*>(b_acc);
             cublasStatus_t err;
@@ -447,8 +447,8 @@ inline sycl::event gemm(const char* func_name, Func func, sycl::queue& queue, tr
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);
@@ -493,8 +493,8 @@ inline sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType_A*>(a);
             auto b_ = reinterpret_cast<const cuDataType_B*>(b);
             auto c_ = reinterpret_cast<cuDataType_C*>(c);
@@ -549,8 +549,8 @@ inline sycl::event symm(const char* func_name, Func func, sycl::queue& queue, si
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);
@@ -591,8 +591,8 @@ inline sycl::event hemm(const char* func_name, Func func, sycl::queue& queue, si
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);
@@ -629,8 +629,8 @@ inline sycl::event syrk(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto c_ = reinterpret_cast<cuDataType*>(c);
             cublasStatus_t err;
@@ -671,8 +671,8 @@ inline sycl::event herk(const char* func_name, Func func, sycl::queue& queue, up
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto c_ = reinterpret_cast<cuDataType*>(c);
             cublasStatus_t err;
@@ -711,8 +711,8 @@ inline sycl::event syr2k(const char* func_name, Func func, sycl::queue& queue, u
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);
@@ -755,8 +755,8 @@ inline sycl::event her2k(const char* func_name, Func func, sycl::queue& queue, u
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<const cuDataType*>(b);
             auto c_ = reinterpret_cast<cuDataType*>(c);
@@ -800,8 +800,8 @@ inline sycl::event trmm(const char* func_name, Func func, sycl::queue& queue, si
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<cuDataType*>(b);
             cublasStatus_t err;
@@ -840,8 +840,8 @@ inline sycl::event trsm(const char* func_name, Func func, sycl::queue& queue, si
         for (int64_t i = 0; i < num_events; i++) {
             cgh.depends_on(dependencies[i]);
         }
-        onemath_cublas_host_task(cgh, queue, [=](CublasScopedContextHandler& sc) {
-            auto handle = sc.get_handle(queue);
+        onemath_cublas_host_task(cgh, [=](CublasScopedContextHandler& sc) {
+            auto handle = sc.get_handle();
             auto a_ = reinterpret_cast<const cuDataType*>(a);
             auto b_ = reinterpret_cast<cuDataType*>(b);
             cublasStatus_t err;

--- a/src/blas/backends/cublas/cublas_scope_handle.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.cpp
@@ -34,9 +34,9 @@ thread_local cublas_handle CublasScopedContextHandler::handle_helper = cublas_ha
 
 CublasScopedContextHandler::CublasScopedContextHandler(sycl::interop_handle& ih) : ih(ih) {}
 
-cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue& queue) {
+cublasHandle_t CublasScopedContextHandler::get_handle() {
     CUdevice device = ih.get_native_device<sycl::backend::ext_oneapi_cuda>();
-    CUstream streamId = get_stream(queue);
+    CUstream streamId = get_stream();
     cublasStatus_t err;
 
     auto it = handle_helper.cublas_handle_mapper_.find(device);
@@ -60,13 +60,9 @@ cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue& queue) 
     return nativeHandle;
 }
 
-CUstream CublasScopedContextHandler::get_stream(const sycl::queue& queue) {
-    return sycl::get_native<sycl::backend::ext_oneapi_cuda>(queue);
+CUstream CublasScopedContextHandler::get_stream() {
+    return ih.get_native_queue<sycl::backend::ext_oneapi_cuda>();
 }
-sycl::context CublasScopedContextHandler::get_context(const sycl::queue& queue) {
-    return queue.get_context();
-}
-
 } // namespace cublas
 } // namespace blas
 } // namespace math

--- a/src/blas/backends/cublas/cublas_scope_handle.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle.hpp
@@ -63,8 +63,7 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 class CublasScopedContextHandler {
     sycl::interop_handle& ih;
     static thread_local cublas_handle handle_helper;
-    CUstream get_stream(const sycl::queue& queue);
-    sycl::context get_context(const sycl::queue& queue);
+    CUstream get_stream();
 
 public:
     CublasScopedContextHandler(sycl::interop_handle& ih);
@@ -73,20 +72,15 @@ public:
    * @brief get_handle: creates the handle by implicitly impose the advice
    * given by nvidia for creating a cublas_handle. (e.g. one cuStream per device
    * per thread).
-   * @param queue sycl queue.
    * @return cublasHandle_t a handle to construct cublas routines
    */
-    cublasHandle_t get_handle(const sycl::queue& queue);
+    cublasHandle_t get_handle();
     // This is a work-around function for reinterpret_casting the memory. This
     // will be fixed when SYCL-2020 has been implemented for Pi backend.
     template <typename T, typename U>
     inline T get_mem(U acc) {
         CUdeviceptr cudaPtr = ih.get_native_mem<sycl::backend::ext_oneapi_cuda>(acc);
         return reinterpret_cast<T>(cudaPtr);
-    }
-
-    void wait_stream(const sycl::queue& queue) {
-        cuStreamSynchronize(get_stream(queue));
     }
 };
 

--- a/src/blas/backends/cublas/cublas_scope_handle_hipsycl.cpp
+++ b/src/blas/backends/cublas/cublas_scope_handle_hipsycl.cpp
@@ -26,13 +26,11 @@ namespace cublas {
 
 thread_local cublas_handle CublasScopedContextHandler::handle_helper = cublas_handle{};
 
-CublasScopedContextHandler::CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle& ih)
-        : interop_h(ih) {}
+CublasScopedContextHandler::CublasScopedContextHandler(sycl::interop_handle& ih) : interop_h(ih) {}
 
-cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue& queue) {
-    sycl::device device = queue.get_device();
+cublasHandle_t CublasScopedContextHandler::get_handle() {
     CUdevice current_device = interop_h.get_native_device<sycl::backend::cuda>();
-    CUstream streamId = get_stream(queue);
+    CUstream streamId = get_stream();
     cublasStatus_t err;
     auto it = handle_helper.cublas_handle_mapper_.find(current_device);
     if (it != handle_helper.cublas_handle_mapper_.end()) {
@@ -54,7 +52,7 @@ cublasHandle_t CublasScopedContextHandler::get_handle(const sycl::queue& queue) 
     return handle;
 }
 
-CUstream CublasScopedContextHandler::get_stream(const sycl::queue& queue) {
+CUstream CublasScopedContextHandler::get_stream() {
     return interop_h.get_native_queue<sycl::backend::cuda>();
 }
 

--- a/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
+++ b/src/blas/backends/cublas/cublas_scope_handle_hipsycl.hpp
@@ -60,13 +60,12 @@ the handle must be destroyed when the context goes out of scope. This will bind 
 class CublasScopedContextHandler {
     sycl::interop_handle interop_h;
     static thread_local cublas_handle handle_helper;
-    sycl::context get_context(const sycl::queue& queue);
-    CUstream get_stream(const sycl::queue& queue);
+    CUstream get_stream();
 
 public:
-    CublasScopedContextHandler(sycl::queue queue, sycl::interop_handle& ih);
+    CublasScopedContextHandler(sycl::interop_handle& ih);
 
-    cublasHandle_t get_handle(const sycl::queue& queue);
+    cublasHandle_t get_handle();
 
     // This is a work-around function for reinterpret_casting the memory. This
     // will be fixed when SYCL-2020 has been implemented for Pi backend.

--- a/src/blas/backends/cublas/cublas_task.hpp
+++ b/src/blas/backends/cublas/cublas_task.hpp
@@ -46,19 +46,19 @@ namespace cublas {
 
 #ifdef __HIPSYCL__
 template <typename H, typename F>
-static inline void host_task_internal(H& cgh, sycl::queue queue, F f) {
-    cgh.hipSYCL_enqueue_custom_operation([f, queue](sycl::interop_handle ih) {
-        auto sc = CublasScopedContextHandler(queue, ih);
+static inline void host_task_internal(H& cgh, F f) {
+    cgh.hipSYCL_enqueue_custom_operation([f](sycl::interop_handle ih) {
+        auto sc = CublasScopedContextHandler(ih);
         f(sc);
     });
 }
 #else
 template <typename H, typename F>
-static inline void host_task_internal(H& cgh, sycl::queue queue, F f) {
+static inline void host_task_internal(H& cgh, F f) {
 #ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
-    cgh.ext_codeplay_enqueue_native_command([f, queue](sycl::interop_handle ih) {
+    cgh.ext_codeplay_enqueue_native_command([f](sycl::interop_handle ih) {
 #else
-    cgh.host_task([f, queue](sycl::interop_handle ih) {
+    cgh.host_task([f](sycl::interop_handle ih) {
 #endif
         auto sc = CublasScopedContextHandler(ih);
         f(sc);
@@ -66,8 +66,8 @@ static inline void host_task_internal(H& cgh, sycl::queue queue, F f) {
 }
 #endif
 template <typename H, typename F>
-static inline void onemath_cublas_host_task(H& cgh, sycl::queue queue, F f) {
-    (void)host_task_internal(cgh, queue, f);
+static inline void onemath_cublas_host_task(H& cgh, F f) {
+    (void)host_task_internal(cgh, f);
 }
 
 } // namespace cublas


### PR DESCRIPTION
A `sycl::queue` object is passed to the `host_task_internal` function as a parameter and used when interacting with a object `CublasScopedContextHandler`. However, the `interop_handle` parameter that is also passed to this entry-point and `CublasScopedContextHandler` constructor is already able to get this information via `interop_handle::get_native_queue()`.

This patch removes the superfluous queue parameters and changes the `CublasScopedContextHandler:get_stream()` implementation to use the `interop_handle` method instead. The unused `get_context()` and `wait_stream` methods are also removed from `CublasScopedContextHandler`