### PR TITLE
Fix preprocessor macros protecting DPC++ bfloat16 extension

### DIFF
--- a/include/oneapi/math/types.hpp
+++ b/include/oneapi/math/types.hpp
@@ -20,20 +20,20 @@
 #ifndef _ONEMATH_TYPES_HPP_
 #define _ONEMATH_TYPES_HPP_
 
-#ifdef __HIPSYCL__
-#include "oneapi/math/bfloat16.hpp"
-#endif
-
 #if __has_include(<sycl/sycl.hpp>)
 #include <sycl/sycl.hpp>
 #else
 #include <CL/sycl.hpp>
 #endif
 
+#ifndef SYCL_IMPLEMENTATION_INTEL
+#include "oneapi/math/bfloat16.hpp"
+#endif
+
 namespace oneapi {
 namespace math {
 
-#ifndef __HIPSYCL__
+#ifdef SYCL_IMPLEMENTATION_INTEL
 using bfloat16 = sycl::ext::oneapi::bfloat16;
 #endif
 


### PR DESCRIPTION
Use the [SYCL2020-standard](https://registry.khronos.org/SYCL/specs/sycl-2020/html/sycl-2020.html#_requirements_for_an_extension) macros `SYCL_IMPLEMENTATION_<vendor>` to decide whether the extension is available or not.

Previous version assumed that if the compiler is not AdaptiveCpp, then it is DPC++. Although these are the only currently supported compilers, such assumptions block the development of support for other SYCL implementations. There is also no good reason to block non-SYCL compilers from parsing the oneMath headers in such a way.

Ideally, the use of an extension should be protected by a specific feature-test macro, but this is currently missing for the DPC++ bfloat16 extension (https://github.com/intel/llvm/issues/18638).

Note DPC++ provides two vendor identifiers `SYCL_IMPLEMENTATION_ONEAPI` and `SYCL_IMPLEMENTATION_INTEL`. The latter is used here to avoid confusion with the name "oneAPI" referring to "oneAPI Math Library" which could mean an internal implementation of a feature in this project.

Fixes #677