### PR TITLE
[LAPACK][tests] Fix is_buf helper for non-DPC++ compilers

### DIFF
--- a/tests/unit_tests/lapack/include/lapack_common.hpp
+++ b/tests/unit_tests/lapack/include/lapack_common.hpp
@@ -231,7 +231,7 @@ struct is_buf {
     static constexpr bool value{ false };
 };
 template <typename T, int dimensions, typename AllocatorT>
-struct is_buf<sycl::buffer<T, dimensions, AllocatorT, void>> {
+struct is_buf<sycl::buffer<T, dimensions, AllocatorT>> {
     static constexpr bool value{ true };
 };
 


### PR DESCRIPTION
# Description
The SYCL standard `buffer` class template has three template arguments. DPC++ [uses a fourth argument](https://github.com/intel/llvm/blob/80a1ff02f445e5a8b09b1f41539ec60d2af14fe3/sycl/include/sycl/buffer.hpp#L168-L173) with a default value using `std::enable_if` in order to prevent compiling code with dimension (second argument) different than 1, 2 or 3. This fourth argument is an implementation detail of DPC++ and SYCL code should not assume its existence.

The LAPACK unit test `is_buf` helper works exactly the same without the fourth argument and aligning it with the SYCL standard fixes a compilation failure with AdaptiveCpp:
```
/work/oneMath/tests/unit_tests/lapack/source/../include/lapack_common.hpp:234:21: error: too many template arguments for class template 'buffer'
  234 | struct is_buf<sycl::buffer<T, dimensions, AllocatorT, void>> {
      |                     ^                                 ~~~~~
/work/AdaptiveCpp/install/bin/../include/AdaptiveCpp/hipSYCL/sycl/buffer.hpp:406:7: note: template is declared here
  404 | template <typename T, int dimensions = 1,
      | ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  405 |           typename AllocatorT = buffer_allocator<std::remove_const_t<T>>>
      |           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  406 | class buffer : public detail::property_carrying_object
      |       ^
```

# Checklist

## All Submissions

- [x] Do all unit tests pass locally? Attach a log.
   - before: [ut-lapack-ref.log.gz](https://github.com/user-attachments/files/20409130/ut-lapack-ref.log.gz)
   - after: [ut-lapack-patch.log.gz](https://github.com/user-attachments/files/20409140/ut-lapack-patch.log.gz)

