### PR TITLE
[BLAS] Avoid blocking wait inside native-command callable

### DIFF
--- a/src/blas/backends/cublas/cublas_level3.cpp
+++ b/src/blas/backends/cublas/cublas_level3.cpp
@@ -95,15 +95,15 @@ inline void gemm_ex(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C, sycl::que
             auto c_ = sc.get_mem<cuDataType_C*>(c_acc);
             cublasStatus_t err;
 #ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+            CUBLAS_ERROR_FUNC(cublasGemmEx, err, handle, get_cublas_operation(transa),
+                              get_cublas_operation(transb), m, n, k, (cuDataType_C*)&alpha, a_,
+                              DT_A, lda, b_, DT_B, ldb, (cuDataType_C*)&beta, c_, DT_C, ldc, DT_C,
+                              CUBLAS_GEMM_DEFAULT);
+#else
             CUBLAS_ERROR_FUNC_SYNC(cublasGemmEx, err, handle, get_cublas_operation(transa),
                                    get_cublas_operation(transb), m, n, k, (cuDataType_C*)&alpha, a_,
                                    DT_A, lda, b_, DT_B, ldb, (cuDataType_C*)&beta, c_, DT_C, ldc,
                                    DT_C, CUBLAS_GEMM_DEFAULT);
-#else
-            CUBLAS_ERROR_FUNC(cublasGemmEx, err, handle, get_cublas_operation(transa),
-                                   get_cublas_operation(transb), m, n, k, (cuDataType_C *)&alpha,
-                                   a_, DT_A, lda, b_, DT_B, ldb, (cuDataType_C *)&beta, c_, DT_C,
-                                   ldc, DT_C, CUBLAS_GEMM_DEFAULT);
 #endif
         });
     });
@@ -500,15 +500,15 @@ inline sycl::event gemm_ex_usm(DATATYPE_A DT_A, DATATYPE_B DT_B, DATATYPE_C DT_C
             auto c_ = reinterpret_cast<cuDataType_C*>(c);
             cublasStatus_t err;
 #ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
+            CUBLAS_ERROR_FUNC(cublasGemmEx, err, handle, get_cublas_operation(transa),
+                              get_cublas_operation(transb), m, n, k, (cuDataType_C*)&alpha, a_,
+                              DT_A, lda, b_, DT_B, ldb, (cuDataType_C*)&beta, c_, DT_C, ldc, DT_C,
+                              CUBLAS_GEMM_DEFAULT);
+#else
             CUBLAS_ERROR_FUNC_SYNC(cublasGemmEx, err, handle, get_cublas_operation(transa),
                                    get_cublas_operation(transb), m, n, k, (cuDataType_C*)&alpha, a_,
                                    DT_A, lda, b_, DT_B, ldb, (cuDataType_C*)&beta, c_, DT_C, ldc,
                                    DT_C, CUBLAS_GEMM_DEFAULT);
-#else
-            CUBLAS_ERROR_FUNC(cublasGemmEx, err, handle, get_cublas_operation(transa),
-                                   get_cublas_operation(transb), m, n, k, (cuDataType_C *)&alpha,
-                                   a_, DT_A, lda, b_, DT_B, ldb, (cuDataType_C *)&beta, c_, DT_C,
-                                   ldc, DT_C, CUBLAS_GEMM_DEFAULT);
 #endif
         });
     });


### PR DESCRIPTION
The `CUBLAS_ERROR_FUNC_SYNC` macro calls `cuStreamSynchronize(currentStreamId);` to synchronize the stream associated with the cuBLAS handle after making the API call, which `CUBLAS_ERROR_FUNC` doesn't.

When using the [sycl_ext_codeplay_enqueue_native_command](https://github.com/intel/llvm/blob/sycl/sycl/doc/extensions/experimental/sycl_ext_codeplay_enqueue_native_command.asciidoc) extension is advised by the specification not to use commands that block

> The function object interopCallable is invoked to enqueue commands to a native queue or graph and therefore, APIs which block or synchronize could prolong or interfere with other commands being enqueued to the backend.

As these will run when the command is submitted before the command-group dependencies have been satisfied.

Instead use the sync variant for the host-task path rather than native enqueue path, which aligns with how
[cublas_batch.cpp](https://github.com/uxlfoundation/oneMath/blob/f09d6cbe2aed9ffef47a6b36b7598322e7cb3104/src/blas/backends/cublas/cublas_batch.cpp#L170) is using a sync variant on the host-task path and not on the native enqueue path.

```cpp
#ifdef SYCL_EXT_ONEAPI_ENQUEUE_NATIVE_COMMAND
            CUBLAS_ERROR_FUNC_T("cublasGemmStridedBatchedEx", cublasGemmStridedBatchedEx, err,
                                handle, get_cublas_operation(transa), get_cublas_operation(transb),
                                m, n, k, &alpha, a_, get_cublas_datatype<cuTypeA>(), lda, stride_a,
                                b_, get_cublas_datatype<cuTypeB>(), ldb, stride_b, &beta, c_,
                                get_cublas_datatype<cuTypeC>(), ldc, stride_c, batch_size,
                                get_cublas_datatype<cuTypeS>(), cublas_gemm_algo);
#else
            CUBLAS_ERROR_FUNC_T_SYNC(
                "cublasGemmStridedBatchedEx", cublasGemmStridedBatchedEx, err, handle,
                get_cublas_operation(transa), get_cublas_operation(transb), m, n, k, &alpha, a_,
                get_cublas_datatype<cuTypeA>(), lda, stride_a, b_, get_cublas_datatype<cuTypeB>(),
                ldb, stride_b, &beta, c_, get_cublas_datatype<cuTypeC>(), ldc, stride_c, batch_size,
                get_cublas_datatype<cuTypeS>(), cublas_gemm_algo);
#endif
```