### PR TITLE
[BLAS][rocblas] PI header includes to applies for only DPC++ compiler

### DIFF
--- a/src/blas/backends/rocblas/rocblas_scope_handle.hpp
+++ b/src/blas/backends/rocblas/rocblas_scope_handle.hpp
@@ -19,7 +19,11 @@
 **************************************************************************/
 #ifndef _ROCBLAS_SCOPED_HANDLE_HPP_
 #define _ROCBLAS_SCOPED_HANDLE_HPP_
+#if __has_include(<sycl/sycl.hpp>)
+#include <sycl/sycl.hpp>
+#else
 #include <CL/sycl.hpp>
+#endif
 #include <memory>
 #include <thread>
 #include <atomic>

--- a/src/blas/backends/rocblas/rocblas_task.hpp
+++ b/src/blas/backends/rocblas/rocblas_task.hpp
@@ -34,18 +34,6 @@
 #include "rocblas_scope_handle_hipsycl.hpp"
 #endif
 
-// After Plugin Interface removal in DPC++ ur.hpp is the new include
-#if __has_include(<sycl/detail/ur.hpp>)
-#include <sycl/detail/ur.hpp>
-#ifndef ONEMATH_PI_INTERFACE_REMOVED
-#define ONEMATH_PI_INTERFACE_REMOVED
-#endif
-#elif __has_include(<sycl/detail/pi.hpp>)
-#include <sycl/detail/pi.hpp>
-#else
-#include <CL/sycl/detail/pi.hpp>
-#endif
-
 namespace oneapi {
 namespace math {
 namespace blas {


### PR DESCRIPTION

# Description

1. Removes preprocessor macro on `pi.hpp` which only applies to DPC++ compiler but not to AdaptiveCPP. This logic is already handled under `backends/rocblas/rocblas_scope_handle.hpp` which is specific to DPC++ and the respective AdaptiveCPP header is already clean `backends/rocblas/rocblas_scope_handle_hipsycl.hpp` 

2. Fixed a deprecated header warning for `CL/sycl.hpp` and placed it under guards.

Fixes #684 

# Checklist

## All Submissions

- [ ] Do all unit tests pass locally? Attach a log.

## New interfaces

- [ ] Have you provided motivation for adding a new feature as part of RFC and
it was accepted? # (RFC)
- [ ] What version of oneAPI spec the interface is targeted?
- [ ] Complete [New features](pull_request_template.md#new-features) checklist

## New features

- [ ] Have you provided motivation for adding a new feature?
- [ ] Have you added relevant tests?

## Bug fixes

- [ ] Have you added relevant regression tests?
- [ ] Have you included information on how to reproduce the issue (either in a
      GitHub issue or in this PR)?
