### PR TITLE
[BLAS] Skip sycl-graph tests on OpenCL and HIP SYCL backends

### DIFF
--- a/tests/unit_tests/blas/sycl-graph/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/sycl-graph/gemm_batch_usm.cpp
@@ -358,8 +358,18 @@ int test(device*, oneapi::math::layout, int64_t, size_t) {
 struct GraphGemmBatchUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {
     virtual void SetUp() override {
+        auto device = std::get<0>(GetParam());
+        if (device->get_backend() == sycl::backend::opencl) {
+            GTEST_SKIP() << "Test not yet supported on OpenCL";
+        }
+#if SYCL_EXT_ONEAPI_BACKEND_HIP
+        if (device->get_backend() == sycl::backend::ext_oneapi_hip) {
+            GTEST_SKIP() << "Test not yet supported on HIP";
+        }
+#endif
+
         // Skip test if graph recording variant and device doesn't support sycl_ext_oneapi_graph
-        CHECK_GRAPH_ON_DEVICE(std::get<0>(GetParam()));
+        CHECK_GRAPH_ON_DEVICE(device);
     }
 };
 

--- a/tests/unit_tests/blas/sycl-graph/gemm_usm.cpp
+++ b/tests/unit_tests/blas/sycl-graph/gemm_usm.cpp
@@ -173,8 +173,18 @@ int test(device*, oneapi::math::layout, int, int, int, int, int, int, Tc, Tc) {
 struct GraphGemmUsmTests
         : public ::testing::TestWithParam<std::tuple<sycl::device*, oneapi::math::layout>> {
     virtual void SetUp() override {
+        auto device = std::get<0>(GetParam());
+        if (device->get_backend() == sycl::backend::opencl) {
+            GTEST_SKIP() << "Test not yet supported on OpenCL";
+        }
+#if SYCL_EXT_ONEAPI_BACKEND_HIP
+        if (device->get_backend() == sycl::backend::ext_oneapi_hip) {
+            GTEST_SKIP() << "Test not yet supported on HIP";
+        }
+#endif
+
         // Skip test if graph recording variant and device doesn't support sycl_ext_oneapi_graph
-        CHECK_GRAPH_ON_DEVICE(std::get<0>(GetParam()));
+        CHECK_GRAPH_ON_DEVICE(device);
     }
 };
 


### PR DESCRIPTION
As reported in https://github.com/uxlfoundation/oneMath/pull/696#issuecomment-3024746970 the sycl-graph blas unit_tests are failing on AMD. Skip these tests until the fails can be investigated functionality can be implemented

CI output from https://github.com/uxlfoundation/oneMath/actions/runs/15996062308/job/45125363025?pr=696
```
Note: Google Test filter = GraphGemmUsmTestSuite/GraphGemmUsmTests.RealSinglePrecision/Column_Major_AMD_EPYC_7763_64_Core_Processor________________
[==========] Running 1 test from 1 test suite.
[----------] Global test environment set-up.
[----------] 1 test from GraphGemmUsmTestSuite/GraphGemmUsmTests
[ RUN      ] GraphGemmUsmTestSuite/GraphGemmUsmTests.RealSinglePrecision/Column_Major_AMD_EPYC_7763_64_Core_Processor________________
relative error = nan absolute error = nan limit = 3.57628e-06
Difference in entry (0,0): DPC++ -nan vs. Reference -nan
relative error = nan absolute error = nan limit = 3.57628e-06
Difference in entry (0,1): DPC++ -nan vs. Reference -nan
/home/runner/work/oneMath/oneMath/tests/unit_tests/blas/sycl-graph/gemm_usm.cpp:193: Failure
Expected equality of these values:
  res
    Which is: 0
  1
[  FAILED  ] GraphGemmUsmTestSuite/GraphGemmUsmTests.RealSinglePrecision/Column_Major_AMD_EPYC_7763_64_Core_Processor________________, where GetParam() = (0x1f4ac940, 1-byte object <01>) (247 ms)
[----------] 1 test from GraphGemmUsmTestSuite/GraphGemmUsmTests (247 ms total)

[----------] Global test environment tear-down
[==========] 1 test from 1 test suite ran. (247 ms total)
[  PASSED  ] 0 tests.
[  FAILED  ] 1 test, listed below:
[  FAILED  ] GraphGemmUsmTestSuite/GraphGemmUsmTests.RealSinglePrecision/Column_Major_AMD_EPYC_7763_64_Core_Processor________________, where GetParam() = (0x1f4ac940, 1-byte object <01>)

 1 FAILED TEST
```

This is failing on an OpenCL CPU backend, my guess is that in [2025.2 Intel OpenCL CPU implementation](https://www.intel.com/content/www/us/en/developer/articles/release-notes/opencl-runtime/2025.html) started supporting cl_khr_command_buffer which is what enables SYCL-Graph on an OpenCL backend. https://github.com/uxlfoundation/oneMath/pull/669 which added these tests didn't take into account the OpenCL path. Enabling this needs further investigation. I've also disabled testing on the HIP backend until the rocm native-command path takes into account graph recording.