### PR TITLE
[LAPACK]  Allow tests to return Skipped status

### DIFF
--- a/tests/unit_tests/lapack/include/lapack_gtest_suite.hpp
+++ b/tests/unit_tests/lapack/include/lapack_gtest_suite.hpp
@@ -80,49 +80,55 @@ using ComplexDoublePrecisionUsm = std::complex<double>;
     DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE);                \
     INSTANTIATE_TEST_CLASS(SUITE, AccuracyUsm)
 
-#define DEFINE_TEST_ACCURACY_USM_REAL(SUITE)                                                   \
-    TEST_P(SUITE##AccuracyUsm, RealSinglePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionUsm>, *GetParam())); \
-    }                                                                                          \
-    TEST_P(SUITE##AccuracyUsm, RealDoublePrecision) {                                          \
-        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                    \
-        test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionUsm>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_USM_REAL(SUITE)                                           \
+    TEST_P(SUITE##AccuracyUsm, RealSinglePrecision) {                                  \
+        test_log::padding = "[          ] ";                                           \
+        EXPECT_TRUEORSKIP(                                                             \
+            accuracy_controller.run(::accuracy<RealSinglePrecisionUsm>, *GetParam())); \
+    }                                                                                  \
+    TEST_P(SUITE##AccuracyUsm, RealDoublePrecision) {                                  \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                            \
+        test_log::padding = "[          ] ";                                           \
+        EXPECT_TRUEORSKIP(                                                             \
+            accuracy_controller.run(::accuracy<RealDoublePrecisionUsm>, *GetParam())); \
     }
 
-#define DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE)                                                   \
-    TEST_P(SUITE##AccuracyUsm, ComplexSinglePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexSinglePrecisionUsm>, *GetParam())); \
-    }                                                                                             \
-    TEST_P(SUITE##AccuracyUsm, ComplexDoublePrecision) {                                          \
-        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                       \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<ComplexDoublePrecisionUsm>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_USM_COMPLEX(SUITE)                                           \
+    TEST_P(SUITE##AccuracyUsm, ComplexSinglePrecision) {                                  \
+        test_log::padding = "[          ] ";                                              \
+        EXPECT_TRUEORSKIP(                                                                \
+            accuracy_controller.run(::accuracy<ComplexSinglePrecisionUsm>, *GetParam())); \
+    }                                                                                     \
+    TEST_P(SUITE##AccuracyUsm, ComplexDoublePrecision) {                                  \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                               \
+        test_log::padding = "[          ] ";                                              \
+        EXPECT_TRUEORSKIP(                                                                \
+            accuracy_controller.run(::accuracy<ComplexDoublePrecisionUsm>, *GetParam())); \
     }
 
-#define DEFINE_TEST_ACCURACY_BUFFER_REAL(SUITE)                                                   \
-    TEST_P(SUITE##AccuracyBuffer, RealSinglePrecision) {                                          \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealSinglePrecisionBuffer>, *GetParam())); \
-    }                                                                                             \
-    TEST_P(SUITE##AccuracyBuffer, RealDoublePrecision) {                                          \
-        CHECK_DOUBLE_ON_DEVICE(GetParam());                                                       \
-        test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(accuracy_controller.run(::accuracy<RealDoublePrecisionBuffer>, *GetParam())); \
+#define DEFINE_TEST_ACCURACY_BUFFER_REAL(SUITE)                                           \
+    TEST_P(SUITE##AccuracyBuffer, RealSinglePrecision) {                                  \
+        test_log::padding = "[          ] ";                                              \
+        EXPECT_TRUEORSKIP(                                                                \
+            accuracy_controller.run(::accuracy<RealSinglePrecisionBuffer>, *GetParam())); \
+    }                                                                                     \
+    TEST_P(SUITE##AccuracyBuffer, RealDoublePrecision) {                                  \
+        CHECK_DOUBLE_ON_DEVICE(GetParam());                                               \
+        test_log::padding = "[          ] ";                                              \
+        EXPECT_TRUEORSKIP(                                                                \
+            accuracy_controller.run(::accuracy<RealDoublePrecisionBuffer>, *GetParam())); \
     }
 
 #define DEFINE_TEST_ACCURACY_BUFFER_COMPLEX(SUITE)                                           \
     TEST_P(SUITE##AccuracyBuffer, ComplexSinglePrecision) {                                  \
         test_log::padding = "[          ] ";                                                 \
-        EXPECT_TRUE(                                                                         \
+        EXPECT_TRUEORSKIP(                                                                   \
             accuracy_controller.run(::accuracy<ComplexSinglePrecisionBuffer>, *GetParam())); \
     }                                                                                        \
     TEST_P(SUITE##AccuracyBuffer, ComplexDoublePrecision) {                                  \
         CHECK_DOUBLE_ON_DEVICE(GetParam());                                                  \
         test_log::padding = "[          ] ";                                                 \
-        EXPECT_TRUE(                                                                         \
+        EXPECT_TRUEORSKIP(                                                                   \
             accuracy_controller.run(::accuracy<ComplexDoublePrecisionBuffer>, *GetParam())); \
     }
 
@@ -145,25 +151,25 @@ using ComplexDoublePrecisionUsm = std::complex<double>;
 #define DEFINE_TEST_DEPENDENCY_REAL(SUITE)                                                     \
     TEST_P(SUITE##DependencyUsm, RealSinglePrecision) {                                        \
         test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(                                                                           \
+        EXPECT_TRUEORSKIP(                                                                     \
             dependency_controller.run(::usm_dependency<RealSinglePrecisionUsm>, *GetParam())); \
     }                                                                                          \
     TEST_P(SUITE##DependencyUsm, RealDoublePrecision) {                                        \
         CHECK_DOUBLE_ON_DEVICE(GetParam());                                                    \
         test_log::padding = "[          ] ";                                                   \
-        EXPECT_TRUE(                                                                           \
+        EXPECT_TRUEORSKIP(                                                                     \
             dependency_controller.run(::usm_dependency<RealDoublePrecisionUsm>, *GetParam())); \
     }
 
 #define DEFINE_TEST_DEPENDENCY_COMPLEX(SUITE)                                                     \
     TEST_P(SUITE##DependencyUsm, ComplexSinglePrecision) {                                        \
         test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(                                                                              \
+        EXPECT_TRUEORSKIP(                                                                        \
             dependency_controller.run(::usm_dependency<ComplexSinglePrecisionUsm>, *GetParam())); \
     }                                                                                             \
     TEST_P(SUITE##DependencyUsm, ComplexDoublePrecision) {                                        \
         CHECK_DOUBLE_ON_DEVICE(GetParam());                                                       \
         test_log::padding = "[          ] ";                                                      \
-        EXPECT_TRUE(                                                                              \
+        EXPECT_TRUEORSKIP(                                                                        \
             dependency_controller.run(::usm_dependency<ComplexDoublePrecisionUsm>, *GetParam())); \
     }\


### PR DESCRIPTION
# Description

Lapack unimplemented or platform-unsupported tests are reported as successful, behaving differently from other backends where "skipped" status is used.
This adds a skipped status to the lapack test harness so that tests are skipped if they are not actually run

# Checklist

## All Submissions

- [x ] Do all unit tests pass locally? Attach a log.
They actually don't pass anymore, but that's expected. For example with Armpl LAPACK, all Batch tests are now skipped. this will probably alter test results in most backends, but that's good imo

100% tests passed, 0 tests failed out of 796

Total Test time (real) =  74.55 sec

The following tests did not run:
        1993 - LAPACK/RT/GeqrfBatchGroup/GeqrfBatchGroupAccuracyUsm.RealSinglePrecision/cpu_neoverse_v2_0xd4f (Skipped)
        1994 - LAPACK/RT/GeqrfBatchGroup/GeqrfBatchGroupAccuracyUsm.RealDoublePrecision/cpu_neoverse_v2_0xd4f (Skipped)
        1995 - LAPACK/RT/GeqrfBatchGroup/GeqrfBatchGroupAccuracyUsm.ComplexSinglePrecision/cpu_neoverse_v2_0xd4f (Skipped)
        1996 - LAPACK/RT/GeqrfBatchGroup/GeqrfBatchGroupAccuracyUsm.ComplexDoublePrecision/cpu_neoverse_v2_0xd4f (Skipped)
        1997 - LAPACK/RT/GeqrfBatchGroup/GeqrfBatchGroupDependencyUsm.RealSinglePrecision/cpu_neoverse_v2_0xd4f (Skipped)
        1998 - LAPACK/RT/GeqrfBatchGroup/GeqrfBatchGroupDependencyUsm.RealDoublePrecision/cpu_neoverse_v2_0xd4f (Skipped)
...

