### PR TITLE
[BLAS] Skip SYCL-Graph tests on L0 backend

### DIFF
--- a/tests/unit_tests/blas/sycl-graph/gemm_batch_usm.cpp
+++ b/tests/unit_tests/blas/sycl-graph/gemm_batch_usm.cpp
@@ -368,6 +368,14 @@ struct GraphGemmBatchUsmTests
         }
 #endif
 
+#if SYCL_EXT_ONEAPI_BACKEND_LEVEL_ZERO
+        // https://github.com/uxlfoundation/oneMath/issues/703
+        // Failing tests reported on PVC that needs investigated
+        if (device->get_backend() == sycl::backend::ext_oneapi_level_zero) {
+            GTEST_SKIP() << "Test disabled on Level-Zero";
+        }
+#endif
+
         // Skip test if graph recording variant and device doesn't support sycl_ext_oneapi_graph
         CHECK_GRAPH_ON_DEVICE(device);
     }


### PR DESCRIPTION
https://github.com/uxlfoundation/oneMath/issues/703 reports an issue with the SYCL-Graph BLAS tests running on PVC with oneAPI 2025.2.

These fails are not expected, so disable tests on L0 until issue can be investigated further.