### PR TITLE
[BLAS][SPARSE][DPC++] Add CUDA_TARGETS option to pass for AoT compila…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,6 +70,7 @@ option(ENABLE_CUSPARSE_BACKEND "Enable the cuSPARSE backend for the SPARSE_BLAS 
 option(ENABLE_ROCSPARSE_BACKEND "Enable the rocSPARSE backend for the SPARSE_BLAS interface" OFF)
 
 set(ONEMATH_SYCL_IMPLEMENTATION "dpc++" CACHE STRING "Name of the SYCL compiler")
+set(CUDA_TARGETS "" CACHE STRING "Target CUDA architectures")
 set(HIP_TARGETS "" CACHE STRING "Target HIP architectures")
 
 ## Testing

--- a/src/blas/backends/cublas/CMakeLists.txt
+++ b/src/blas/backends/cublas/CMakeLists.txt
@@ -41,12 +41,21 @@ target_include_directories(${LIB_OBJ}
 )
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMATH_BUILD_COPT})
 
-if(NOT ${ONEMATH_SYCL_IMPLEMENTATION} STREQUAL "adaptivecpp")
-  if(DEFINED CUDA_TARGETS)
+if (NOT "${ONEMATH_SYCL_IMPLEMENTATION}" STREQUAL "adaptivecpp")
+  target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
+    -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda
+  )
+  target_link_options(ONEMATH::SYCL::SYCL INTERFACE
+    -fsycl-targets=nvptx64-nvidia-cuda
+  )
+
+  if (DEFINED CUDA_TARGETS AND NOT "${CUDA_TARGETS}" STREQUAL "")
     target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
-      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS}
+    )
     target_link_options(ONEMATH::SYCL::SYCL INTERFACE
-      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS}
+    )
   endif()
 endif()
 

--- a/src/blas/backends/cublas/CMakeLists.txt
+++ b/src/blas/backends/cublas/CMakeLists.txt
@@ -42,11 +42,14 @@ target_include_directories(${LIB_OBJ}
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMATH_BUILD_COPT})
 
 if(NOT ${ONEMATH_SYCL_IMPLEMENTATION} STREQUAL "adaptivecpp")
+  if(DEFINED CUDA_TARGETS)
     target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
-          -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
     target_link_options(ONEMATH::SYCL::SYCL INTERFACE
-          -fsycl-targets=nvptx64-nvidia-cuda)
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+  endif()
 endif()
+
 target_link_libraries(${LIB_OBJ} PUBLIC ONEMATH::SYCL::SYCL ONEMATH::cuBLAS::cuBLAS)
 target_compile_features(${LIB_OBJ} PUBLIC cxx_std_11)
 set_target_properties(${LIB_OBJ} PROPERTIES

--- a/src/blas/backends/generic/CMakeLists.txt
+++ b/src/blas/backends/generic/CMakeLists.txt
@@ -82,11 +82,11 @@ if(GENERIC_BLAS_TUNING_TARGET)
         -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda)
       target_link_options(ONEMATH::SYCL::SYCL INTERFACE
         -fsycl-targets=nvptx64-nvidia-cuda)
-      if(DEFINED CUDA_TARGET)
+      if(DEFINED CUDA_TARGETS)
         target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
-          -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGET})
+          -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
         target_link_options(ONEMATH::SYCL::SYCL INTERFACE
-          -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGET})
+          -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
       endif()
     else()
       message(WARNING "Compiler is not supported."

--- a/src/sparse_blas/backends/cusparse/CMakeLists.txt
+++ b/src/sparse_blas/backends/cusparse/CMakeLists.txt
@@ -43,12 +43,21 @@ target_include_directories(${LIB_OBJ}
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMATH_BUILD_COPT})
 
-if(NOT ${ONEMATH_SYCL_IMPLEMENTATION} STREQUAL "adaptivecpp")
-  if(DEFINED CUDA_TARGETS)
+if (NOT "${ONEMATH_SYCL_IMPLEMENTATION}" STREQUAL "adaptivecpp")
+  target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
+    -fsycl-targets=nvptx64-nvidia-cuda -fsycl-unnamed-lambda
+  )
+  target_link_options(ONEMATH::SYCL::SYCL INTERFACE
+    -fsycl-targets=nvptx64-nvidia-cuda
+  )
+
+  if (DEFINED CUDA_TARGETS AND NOT "${CUDA_TARGETS}" STREQUAL "")
     target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
-      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS}
+    )
     target_link_options(ONEMATH::SYCL::SYCL INTERFACE
-      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS}
+    )
   endif()
 endif()
 

--- a/src/sparse_blas/backends/cusparse/CMakeLists.txt
+++ b/src/sparse_blas/backends/cusparse/CMakeLists.txt
@@ -43,6 +43,15 @@ target_include_directories(${LIB_OBJ}
 
 target_compile_options(${LIB_OBJ} PRIVATE ${ONEMATH_BUILD_COPT})
 
+if(NOT ${ONEMATH_SYCL_IMPLEMENTATION} STREQUAL "adaptivecpp")
+  if(DEFINED CUDA_TARGETS)
+    target_compile_options(ONEMATH::SYCL::SYCL INTERFACE
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+    target_link_options(ONEMATH::SYCL::SYCL INTERFACE
+      -Xsycl-target-backend --cuda-gpu-arch=${CUDA_TARGETS})
+  endif()
+endif()
+
 if (${CMAKE_VERSION} VERSION_LESS "3.17.0")
   find_package(CUDA 12.2 REQUIRED)
   target_include_directories(${LIB_OBJ} PRIVATE ${CUDA_INCLUDE_DIRS})


### PR DESCRIPTION
…tion

1. Adds an option to use `CUDA_TARGETS` similar to existing option for `HIP_TARGETS` for AoT builds of DPC++ compiler
2. `generic` `blas` already has stubs to use arch flags but was not set