### PR TITLE
[cmake] remove the latest lib directories from MKLConfig

### DIFF
--- a/cmake/mkl/MKLConfig.cmake
+++ b/cmake/mkl/MKLConfig.cmake
@@ -980,11 +980,6 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
              "windows/compiler/lib/${MKL_ARCH}_win"
              "../compiler/lib/${MKL_ARCH}_lin" "../compiler/lib/${MKL_ARCH}_win"
              "../compiler/lib/${MKL_ARCH}" "../compiler/lib" "compiler/lib"
-             "../../compiler/latest/lib"
-             "../../compiler/latest/linux/compiler/lib/${MKL_ARCH}"
-             "../../compiler/latest/linux/compiler/lib/${MKL_ARCH}_lin"
-             "../../compiler/latest/windows/compiler/lib/${MKL_ARCH}"
-             "../../compiler/latest/windows/compiler/lib/${MKL_ARCH}_win"
       NO_DEFAULT_PATH)
     if(WIN32)
       set(OMP_DLLNAME ${LIB_PREFIX}${MKL_OMP_LIB}.dll)
@@ -995,11 +990,6 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
               "redist/${MKL_ARCH}"
               "redist/${MKL_ARCH}_win" "redist/${MKL_ARCH}_win/compiler"
               "../redist/${MKL_ARCH}/compiler" "../compiler/lib"
-              "../../compiler/latest/bin"
-              "../../compiler/latest/windows/redist/${MKL_ARCH}_win"
-              "../../compiler/latest/windows/redist/${MKL_ARCH}_win/compiler"
-              "../../compiler/latest/windows/compiler/redist/${MKL_ARCH}_win"
-              "../../compiler/latest/windows/compiler/redist/${MKL_ARCH}_win/compiler"
         NO_DEFAULT_PATH)
       if(MKL_LINK STREQUAL "sdl" AND NOT OMP_DLL_DIR)
         mkl_message(WARNING "${OMP_DLLNAME} not found. MKL_ENV will not contain paths for ${OMP_DLLNAME}.")


### PR DESCRIPTION
# Description

Fix oneAPI version pollution in a multiple-version environment. 

## Bug Description: 
In a system with two oneAPI versions (2025.2 and 2025.3), if I activate oneapi_var.sh of 2025.2 `source ~/intel/oneapi/2025.2/oneapi-vars.sh `, and compile my SYCL-TLA project, which links MKL in [cmake](https://github.com/intel/sycl-tla/blob/main/cmake/onemkl.cmake#L38).
`find_package(MKL CONFIG QUIET PATHS $ENV{MKLROOT})`
In CMake, the target MKL::MKL has these libs in its INTERFACE_LINK_LIBRARIES:
```
--     - -Wl,-rpath=$<TARGET_FILE_DIR:MKL::mkl_core>
--     - MKL::mkl_intel_ilp64
--     - MKL::mkl_intel_thread
--     - MKL::mkl_core
--     - /home/yuluo/intel/oneapi/compiler/latest/lib/libiomp5.so
--     - -lm
--     - -ldl
--     - -lpthread
```
You can see it links to the latest libiomp5.so, which is under oneAPI 2025.3. The worst part of this bug is that the latest libiomp5.so polluted my whole project's oneAPI version to 2025.3. Then I will see these warnings from the CMake console:
 ```
   Cannot generate a safe runtime search path for target
    cutlass_library_gemm_xe20_gemm because files in some directories may
    conflict with libraries in implicit directories:
  
      runtime library [libsycl.so.8] in /home/yuluo/intel/oneapi/compiler/2025.2/lib may be hidden by files in:
        /home/yuluo/intel/oneapi/compiler/latest/lib
```
The latest libiomp5.so added the latest oneAPI to the compiler's link `rpath`, as:
`/home/yuluo/intel/oneapi/2025.2/bin/icpx  -DCUTLASS_VERSIONS_GENERATED -O3 -DNDEBUG -fsycl -fno-sycl-instrument-device-code -fsycl-targets=spir64 -Xs "-device bmg_g21" -Xspirv-translator -spirv-ext=+SPV_INTEL_split_barrier,+SPV_INTEL_2d_block_io,+SPV_INTEL_subgroup_matrix_multiply_accumulate -Wl,--dependency-file=CMakeFiles/copy_debug.dir/link.d CMakeFiles/copy_debug.dir/copy_debug.cpp.o -o copy_debug   -L/lib64/stubs  -Wl,-rpath,/lib64/stubs:/home/yuluo/intel/oneapi/compiler/latest/lib -Wl,-rpath=/home/yuluo/intel/oneapi/2025.2/lib /home/yuluo/intel/oneapi/2025.2/lib/libmkl_intel_ilp64.so /home/yuluo/intel/oneapi/2025.2/lib/libmkl_intel_thread.so /home/yuluo/intel/oneapi/2025.2/lib/libmkl_core.so /home/yuluo/intel/oneapi/compiler/latest/lib/libiomp5.so -lm -ldl -lpthread`

The key issue is this option: `-Wl,-rpath,/lib64/stubs:/home/yuluo/intel/oneapi/compiler/latest/lib`
With the polluted oneAPI version, my project caused these link errors:
```
/usr/bin/ld: /home/yuluo/intel/oneapi/compiler/2025.2/bin/compiler/../../lib/libsycl.so: undefined reference to `urEnqueueCooperativeKernelLaunchExp@LIBUR_LOADER_0.12'
/usr/bin/ld: /home/yuluo/intel/oneapi/compiler/2025.2/bin/compiler/../../lib/libsycl.so: undefined reference to `urKernelSuggestMaxCooperativeGroupCountExp@LIBUR_LOADER_0.12'
/usr/bin/ld: /home/yuluo/intel/oneapi/compiler/2025.2/bin/compiler/../../lib/libsycl.so: undefined reference to `urEnqueueKernelLaunchCustomExp@LIBUR_LOADER_0.12'
```

## Fix
remove the latest lib directories from MKLConfig.
After fix, MKL::MKL links to `/home/yuluo/intel/oneapi/2025.2/lib/libiomp5.so`.  There are no CMake warnings or link errors. CMake passes the correct **rpath** to dpcpp:
`/home/yuluo/intel/oneapi/2025.2/bin/icpx  -DCUTLASS_VERSIONS_GENERATED -O3 -DNDEBUG -fsycl -fno-sycl-instrument-device-code -fsycl-targets=spir64 -Xs "-device bmg_g21" -Xspirv-translator -spirv-ext=+SPV_INTEL_split_barrier,+SPV_INTEL_2d_block_io,+SPV_INTEL_subgroup_matrix_multiply_accumulate -Wl,--dependency-file=CMakeFiles/copy_debug.dir/link.d CMakeFiles/copy_debug.dir/copy_debug.cpp.o -o copy_debug   -L/lib64/stubs  -Wl,-rpath,/lib64/stubs -Wl,-rpath=/home/yuluo/intel/oneapi/2025.2/lib /home/yuluo/intel/oneapi/2025.2/lib/libmkl_intel_ilp64.so /home/yuluo/intel/oneapi/2025.2/lib/libmkl_intel_thread.so /home/yuluo/intel/oneapi/2025.2/lib/libmkl_core.so /home/yuluo/intel/oneapi/2025.2/lib/libiomp5.so -lm -ldl -lpthread`