### PR TITLE
Fix failing ArmPL SCAL tests

### DIFF
--- a/src/blas/backends/armpl/armpl_level1.cxx
+++ b/src/blas/backends/armpl/armpl_level1.cxx
@@ -347,7 +347,8 @@ void scal(sycl::queue& queue, int64_t n, T alpha, sycl::buffer<U, 1>& x, int64_t
     queue.submit([&](sycl::handler& cgh) {
         auto accessor_x = x.template get_access<sycl::access::mode::read_write>(cgh);
         host_task<class armpl_kernel_scal>(cgh, [=]() {
-            cblas_func(n, cast_to_void_if_complex(alpha), accessor_x.GET_MULTI_PTR, incx);
+            cblas_func(n, cast_to_void_if_complex(alpha), accessor_x.GET_MULTI_PTR,
+                       (const int)std::abs(incx));
         });
     });
 }


### PR DESCRIPTION
# Description

The BLAS SCAL function returns immediately if INCX<=0. The reference USM calls pass in ABS(INCX) but the ArmPL calls were just passing in INCX. We were therefore comparing functions called with two different inputs, and the tests were failing. The fix is to pass ABS(INCX) into the ArmPL calls as well, in common with other ArmPL calls to BLAS functions in this file (e.g. compare the ArmPL and USM nrm2 calls).

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? Attach a log.
[test.log](https://github.com/user-attachments/files/26964849/test.log)