### PR TITLE
Fix empty commit error in documentation publish workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -54,6 +54,10 @@ jobs:
         cd gh-pages
         touch .nojekyll
         git add .
+        if git diff --cached --quiet; then
+          echo "No documentation changes to publish"
+          exit 0
+        fi
         git config --global user.name "GitHub Actions"
         git config --global user.email github-actions@github.com
         git commit -m "Update documentation"


### PR DESCRIPTION
# Fix empty commit error in documentation publish workflow

See https://github.com/uxlfoundation/oneMath/actions/runs/26177212473/workflow

## Summary
- Adds a check to detect when there are no documentation changes to publish
- Prevents empty commits that cause the documentation workflow to fail
- Exits gracefully with a message when no changes are detected

🤖 Generated with [Claude Code](https://claude.com/claude-code)
