### PR TITLE
Update GitHub Actions to latest versions in documentation workflow

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -16,8 +16,8 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
-    - uses: actions/setup-python@82c7e631bb3cdc910f68e0081d67478d79c6982d # v5.1.0
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+    - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
       with:
         python-version: '3.11'
         cache: 'pip'
@@ -27,7 +27,7 @@ jobs:
       run: |
         cmake -DCMAKE_VERBOSE_MAKEFILE=on -B build docs
         cmake --build build
-    - uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
+    - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: docs
         path: build/Documentation/html
@@ -39,13 +39,13 @@ jobs:
     permissions:
       contents: write
     steps:
-    - uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with:
         ref: gh-pages
         path: gh-pages
     - name: Remove old site
       run: rm -rf gh-pages/*
-    - uses: actions/download-artifact@65a9edc5881444af0b9093a5e628f2fe47ea3b2e # v4.1.7
+    - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
       with:
         name: docs
         path: gh-pages


### PR DESCRIPTION
# Update GitHub Actions to latest versions in documentation workflow

## Summary
- Updates all GitHub Actions in documentation.yml to their latest versions
- Maintains SHA pinning for security best practices
- actions/checkout: v4.1.5 → v6.0.2
- actions/setup-python: v5.1.0 → v6.2.0
- actions/upload-artifact: v4.3.3 → v7.0.1
- actions/download-artifact: v4.1.7 → v8.0.1

## Rationale
SHA pinning is still the recommended security best practice for GitHub Actions, but the versions were outdated. This updates to the latest releases to get bug fixes and security patches while maintaining the security benefits of SHA pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
