### PR TITLE
Add Dependabot configuration for automated dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+  # Python dependencies for documentation
+  - package-ecosystem: "pip"
+    directory: "/docs"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "deps"
+      include: "scope"
+
+  # GitHub Actions across all workflows
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci"
+      include: "scope"


### PR DESCRIPTION
# Add Dependabot configuration for automated dependency updates

## Summary
- Adds `.github/dependabot.yml` to automate dependency updates
- Configures weekly checks for Python dependencies (docs/requirements.txt)
- Configures weekly checks for GitHub Actions across all workflows
- Dependabot will maintain SHA pinning format for GitHub Actions
- Replaces default dependabot, that was updating requirements.doc, but was not updating github actions. e.g. https://github.com/uxlfoundation/oneMath/pull/729

## Benefits
- Automated PRs for security patches and bug fixes
- Continues current SHA pinning best practice for Actions
- Reduces manual maintenance burden
- Ensures dependencies stay current

🤖 Generated with [Claude Code](https://claude.com/claude-code)
