### PR TITLE
[workflows][cmake] update oneMKL to 2026.0 release

### DIFF
--- a/.github/workflows/coverity.yml
+++ b/.github/workflows/coverity.yml
@@ -55,14 +55,14 @@ jobs:
 
       - name: Install Intel compiler
         run: |
-          wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5adfc398-db78-488c-b98f-78461b3c5760/intel-dpcpp-cpp-compiler-2025.3.1.16_offline.sh
-          sudo bash intel-dpcpp-cpp-compiler-2025.3.1.16_offline.sh -s -a -s --action install --eula accept
+          wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e2f4cda3-8891-4d0e-bf60-00d19c4e3e27/intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh
+          sudo bash intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh -s -a -s --action install --eula accept
 
 
       - name: Install Intel oneMKL
         run: |
-          wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2ad98b49-1fb2-4294-ab3d-6889b434ebd3/intel-onemkl-2025.3.0.462_offline.sh
-          sudo bash intel-onemkl-2025.3.0.462_offline.sh -s -a -s --action install --eula accept
+          wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/db60f483-f02e-4f7e-9bcd-5e01dba97444/intel-onemkl-2026.0.0.909_offline.sh
+          sudo bash intel-onemkl-2026.0.0.909_offline.sh -s -a -s --action install --eula accept
 
       - name: Restore netlib from cache
         id: cache-lapack

--- a/.github/workflows/pr-x86.yml
+++ b/.github/workflows/pr-x86.yml
@@ -68,13 +68,13 @@ jobs:
     - name: Install compiler
       if: steps.domain_check.outputs.result == 'true'
       run: |
-        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/5adfc398-db78-488c-b98f-78461b3c5760/intel-dpcpp-cpp-compiler-2025.3.1.16_offline.sh
-        sudo bash intel-dpcpp-cpp-compiler-2025.3.1.16_offline.sh -s -a -s --action install --eula accept
+        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/e2f4cda3-8891-4d0e-bf60-00d19c4e3e27/intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh
+        sudo bash intel-dpcpp-cpp-compiler-2026.0.0.564_offline.sh -s -a -s --action install --eula accept
     - name: Install Intel oneMKL
       if: steps.domain_check.outputs.result == 'true'
       run: |
-        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/2ad98b49-1fb2-4294-ab3d-6889b434ebd3/intel-onemkl-2025.3.0.462_offline.sh
-        sudo bash intel-onemkl-2025.3.0.462_offline.sh -s -a -s --action install --eula accept
+        wget --progress=dot:giga https://registrationcenter-download.intel.com/akdlm/IRC_NAS/db60f483-f02e-4f7e-9bcd-5e01dba97444/intel-onemkl-2026.0.0.909_offline.sh
+        sudo bash intel-onemkl-2026.0.0.909_offline.sh -s -a -s --action install --eula accept
     - name: Configure/Build for a domain
       if: steps.domain_check.outputs.result == 'true'
       run: |

--- a/cmake/mkl/MKLConfig.cmake
+++ b/cmake/mkl/MKLConfig.cmake
@@ -32,7 +32,8 @@
 # MKL_LINK
 #    Values:  static, dynamic, sdl
 #    Default: dynamic
-#       Exceptions: SYCL doesn't support sdl
+#       Exceptions: SYCL doesn't support static and sdl
+#                   OpenMP Offload doesn't support static
 # MKL_THREADING
 #    Values:  sequential,
 #             intel_thread (Intel OpenMP),
@@ -315,8 +316,10 @@ endif()
 #================
 
 # Extensions
-set(SO_VER "2")
-set(SYCL_SO_VER "5")
+set(SO_VER "3")
+set(CLUSTER_SO_VER "2")
+set(SYCL_SO_VER "6")
+set(DIST_SYCL_SO_VER "2")
 if(UNIX)
   set(LIB_PREFIX "lib")
   set(LIB_EXT ".a")
@@ -379,9 +382,9 @@ define_param(MKL_ARCH DEFAULT_MKL_ARCH MKL_ARCH_LIST)
 check_required_vars(MKL_ARCH)
 
 # Define MKL_LINK
-if(SYCL_COMPILER)
+if(SYCL_COMPILER OR (ENABLE_OMP_OFFLOAD AND MKL_LINK STREQUAL "static"))
   set(DEFAULT_MKL_SYCL_LINK dynamic)
-  set(MKL_SYCL_LINK_LIST static dynamic)
+  set(MKL_SYCL_LINK_LIST dynamic)
   if(NOT DEFINED MKL_SYCL_LINK)
     set(MKL_SYCL_LINK ${MKL_LINK})
   endif()
@@ -399,15 +402,6 @@ else()
 endif()
 define_param(MKL_LINK DEFAULT_MKL_LINK MKL_LINK_LIST)
 check_required_vars(MKL_LINK)
-
-if(MKL_LINK STREQUAL "static" AND ENABLE_OMP_OFFLOAD)
-  mkl_message(WARNING "oneMKL SYCL static library is deprecated and will be removed in the oneMKL 2026.0 release")
-elseif(MKL_SYCL_LINK AND MKL_SYCL_LINK STREQUAL "static")
-  mkl_message(STATUS "oneMKL SYCL static library is deprecated and will be removed in the oneMKL 2026.0 release")
-  add_custom_target(MKL_SYCL_STATIC_MESSAGE
-                    COMMAND ${CMAKE_COMMAND} -E cmake_echo_color --red
-                    "Warning: oneMKL SYCL static library is deprecated and will be removed in the oneMKL 2026.0 release")
-endif()
 
 # Define MKL_INTERFACE
 if(SYCL_COMPILER)
@@ -458,6 +452,9 @@ endif()
 # SYCL API supports oneTBB and OpenMP threadings
 if(SYCL_COMPILER)
   set(MKL_SYCL_THREADING_LIST "sequential" "intel_thread" "tbb_thread")
+  if(NOT WIN32)
+    list(APPEND MKL_SYCL_THREADING_LIST gnu_thread)
+  endif()
   set(DEFAULT_MKL_SYCL_THREADING tbb_thread)
   if(NOT DEFINED MKL_SYCL_THREADING)
     set(MKL_SYCL_THREADING ${MKL_THREADING})
@@ -471,11 +468,8 @@ endif()
 # C, Fortran API
 set(MKL_THREADING_LIST "sequential" "intel_thread" "tbb_thread")
 set(DEFAULT_MKL_THREADING intel_thread)
-if(GNU_C_COMPILER OR GNU_Fortran_COMPILER OR CLANG_COMPILER)
+if(NOT WIN32)
   list(APPEND MKL_THREADING_LIST gnu_thread)
-else()
-  # Intel and Microsoft compilers
-  # Nothing to do, only for completeness
 endif()
 define_param(MKL_THREADING DEFAULT_MKL_THREADING MKL_THREADING_LIST)
 check_required_vars(MKL_THREADING)
@@ -560,22 +554,8 @@ endif()
 if(SYCL_COMPILER)
   list(APPEND MKL_SYCL_COPT "-fsycl")
   list(APPEND MKL_SYCL_LOPT "-fsycl")
-  if(MKL_SYCL_LINK STREQUAL "static")
-    if(WIN32)
-      list(APPEND MKL_SYCL_LOPT "-fsycl-device-code-split:per_kernel")
-    else()
-      list(APPEND MKL_SYCL_LOPT "-fsycl-device-code-split=per_kernel")
-    endif()
-  endif()
-endif()
-if(ENABLE_OMP_OFFLOAD)
-  if(MKL_LINK STREQUAL "static")
-    if(WIN32)
-      list(APPEND MKL_OFFLOAD_LOPT "-fsycl-device-code-split:per_kernel")
-    else()
-      list(APPEND MKL_OFFLOAD_LOPT "-fsycl-device-code-split=per_kernel")
-    endif()
-  endif()
+  # Enable Device API accessibility from dynamic libraries
+  list(APPEND MKL_SYCL_LOPT "-fsycl-allow-device-image-dependencies")
 endif()
 
 # For OpenMP Offload
@@ -667,20 +647,12 @@ list(APPEND MKL_SYCL_LIBS mkl_sycl_data_fitting)
 list(APPEND MKL_SYCL_LIBS mkl_sycl_rng)
 list(APPEND MKL_SYCL_LIBS mkl_sycl_stats)
 list(APPEND MKL_SYCL_LIBS mkl_sycl_vm)
-if(NOT MKL_LINK STREQUAL "static")
-  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
-    list(TRANSFORM MKL_SYCL_LIBS APPEND "d")
-  endif()
-  list(APPEND MKL_SYCL ${MKL_SYCL_LIBS})
-  # List for tracking incomplete onemKL package
-  set(MISSED_MKL_SYCL_LIBS)
-else()
-  if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
-    set(MKL_SYCL         mkl_sycld)
-  else()
-    set(MKL_SYCL         mkl_sycl)
-  endif()
+if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
+  list(TRANSFORM MKL_SYCL_LIBS APPEND "d")
 endif()
+list(APPEND MKL_SYCL ${MKL_SYCL_LIBS})
+# List for tracking incomplete onemKL package
+set(MISSED_MKL_SYCL_LIBS)
 set(MKL_SYCL_DISTRIBUTED_DFT mkl_sycl_distributed_dft)
 
 set(MKL_IFACE_LIB   mkl_${MKL_INTERFACE_FULL})
@@ -721,15 +693,9 @@ set(MKL_CDFT      mkl_cdft_core)
 set(MKL_SCALAPACK mkl_scalapack_${MKL_INTERFACE})
 
 if(UNIX)
-  if(MKL_LINK STREQUAL "static" OR MKL_SYCL_LINK STREQUAL "static")
+  if(MKL_LINK STREQUAL "static")
     set(START_GROUP "-Wl,--start-group")
     set(END_GROUP "-Wl,--end-group")
-    if(SYCL_COMPILER)
-      set(SYCL_EXPORT_DYNAMIC "-Wl,-export-dynamic")
-    endif()
-    if(ENABLE_OMP_OFFLOAD)
-      set(EXPORT_DYNAMIC "-Wl,-export-dynamic")
-    endif()
   endif()
   if(MKL_LINK STREQUAL "dynamic")
     set(MKL_RPATH "-Wl,-rpath=$<TARGET_FILE_DIR:MKL::${MKL_CORE}>")
@@ -821,14 +787,16 @@ foreach(lib ${MKL_REQUESTED_LIBRARIES})
   else()
     find_library(${lib}_file NAMES ${LIB_PREFIX}${lib}${DLL_EXT}
                   ${LIB_PREFIX}${lib}${DLL_EXT}.${SO_VER}
+                  ${LIB_PREFIX}${lib}${DLL_EXT}.${CLUSTER_SO_VER}
                   ${LIB_PREFIX}${lib}${DLL_EXT}.${SYCL_SO_VER}
+                  ${LIB_PREFIX}${lib}${DLL_EXT}.${DIST_SYCL_SO_VER}
                   ${lib}
                   PATHS ${MKL_ROOT}
                   PATH_SUFFIXES "lib"
                   NO_DEFAULT_PATH)
     add_library(MKL::${lib} SHARED IMPORTED)
   endif()
-  if(NOT MKL_LINK STREQUAL "static" AND (${lib} MATCHES "mkl_sycl" AND NOT ${lib} STREQUAL "mkl_sycl_distributed_dft") AND ${${lib}_file} STREQUAL "${lib}_file-NOTFOUND")
+  if((${lib} MATCHES "mkl_sycl" AND NOT ${lib} STREQUAL "mkl_sycl_distributed_dft") AND ${${lib}_file} STREQUAL "${lib}_file-NOTFOUND")
     list(APPEND MISSED_MKL_SYCL_LIBS ${lib})
     set(MKL_SYCL_DOMAIN "")
     string(REGEX REPLACE "mkl_sycl_" "" MKL_SYCL_DOMAIN ${lib})
@@ -906,9 +874,8 @@ endforeach()
 
 # Threading selection
 if(MKL_THREADING STREQUAL "tbb_thread" OR MKL_SYCL_THREADING STREQUAL "tbb_thread")
-  set(TBB_FIND_RELEASE_ONLY TRUE) # Do not use tbb_debug
   find_package(TBB CONFIG COMPONENTS tbb)
-  if(NOT TBB_tbb_FOUND)
+  if(NOT TARGET TBB::tbb)
     if(MKL_THREADING STREQUAL "tbb_thread")
       if(NOT MKL_LINK STREQUAL "sdl")
         mkl_not_found_and_return("TBB not found for the specified MKL_THREADING: ${MKL_THREADING}")
@@ -927,7 +894,17 @@ if(MKL_THREADING STREQUAL "tbb_thread" OR MKL_SYCL_THREADING STREQUAL "tbb_threa
     if(MKL_SYCL_THREADING STREQUAL "tbb_thread")
       set(MKL_SYCL_THREAD_LIB $<TARGET_LINKER_FILE:TBB::tbb>)
     endif()
-    get_property(TBB_LIB TARGET TBB::tbb PROPERTY IMPORTED_LOCATION_RELEASE)
+    if(CMAKE_BUILD_TYPE MATCHES "Debug")
+      get_property(TBB_LIB TARGET TBB::tbb PROPERTY IMPORTED_LOCATION_DEBUG)
+    else()
+      get_property(TBB_LIB TARGET TBB::tbb PROPERTY IMPORTED_LOCATION_RELEASE)
+    endif()
+    if(NOT TBB_LIB)
+      # Fatal error because none of the TBB variants were found
+      mkl_not_found_and_return("TBB not found on the filesystem.")
+    endif()
+    # TBB_LIB will always have a non-empty value here
+    mkl_message(STATUS "Found ${TBB_LIB}")
     get_filename_component(TBB_LIB_DIR ${TBB_LIB} DIRECTORY)
     if(UNIX)
       if(CMAKE_SKIP_BUILD_RPATH)
@@ -959,6 +936,9 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
   if(MKL_THREADING STREQUAL "gnu_thread")
     if(NOT MKL_LINK STREQUAL "sdl")
       list(APPEND MKL_SUPP_LINK -lgomp)
+      if(MKL_SYCL_THREADING STREQUAL "gnu_thread")
+        set(MKL_SYCL_THREAD_LIB -lgomp)
+      endif()
     endif()
   else()
     # intel_thread
@@ -972,7 +952,8 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
 
     find_library(OMP_LIBRARY ${OMP_LIBNAME}
       HINTS $ENV{LIB} ${ENV_LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
-      PATH_SUFFIXES "lib" "lib/${MKL_ARCH}"
+      PATH_SUFFIXES "../../compiler/2026.0/lib"
+             "lib" "lib/${MKL_ARCH}"
              "lib/${MKL_ARCH}_lin" "lib/${MKL_ARCH}_win"
              "linux/compiler/lib/${MKL_ARCH}"
              "linux/compiler/lib/${MKL_ARCH}_lin"
@@ -985,7 +966,8 @@ if(NOT MKL_THREADING STREQUAL "tbb_thread" AND MKL_THREADING MATCHES "_thread")
       set(OMP_DLLNAME ${LIB_PREFIX}${MKL_OMP_LIB}.dll)
       find_path(OMP_DLL_DIR ${OMP_DLLNAME}
         HINTS $ENV{LIB} ${ENV_LIBRARY_PATH} $ENV{MKLROOT} ${MKL_ROOT} $ENV{CMPLR_ROOT}
-        PATH_SUFFIXES "bin"
+        PATH_SUFFIXES "../../compiler/2026.0/bin"
+              "bin"
               # Legacy layout support for oneMKL
               "redist/${MKL_ARCH}"
               "redist/${MKL_ARCH}_win" "redist/${MKL_ARCH}_win/compiler"
@@ -1025,22 +1007,12 @@ if(UNIX)
   list(APPEND MKL_SUPP_LINK -lm -ldl -lpthread)
 endif()
 
-if(SYCL_COMPILER OR ENABLE_OMP_OFFLOAD)
-  if(SYCL_COMPILER)
-    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
-      list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}sycld${LINK_SUFFIX})
-    else()
-      list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}sycl${LINK_SUFFIX})
-    endif()
-    list(APPEND MKL_SYCL_SUPP_LINK ${LINK_PREFIX}OpenCL${LINK_SUFFIX})
-  endif()
-  if(ENABLE_OMP_OFFLOAD)
-    if(WIN32 AND CMAKE_BUILD_TYPE MATCHES "Debug")
-      list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycld${LINK_SUFFIX})
-    else()
-      list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycl${LINK_SUFFIX})
-    endif()
-    list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}OpenCL${LINK_SUFFIX})
+# icx with OMP Offload feature needs SYCL library explicitly in the link line on Windows
+if(ENABLE_OMP_OFFLOAD AND WIN32)
+  if(CMAKE_BUILD_TYPE MATCHES "Debug")
+    list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycld${LINK_SUFFIX})
+  else()
+    list(APPEND MKL_SUPP_LINK ${LINK_PREFIX}sycl${LINK_SUFFIX})
   endif()
 endif()
 
@@ -1054,6 +1026,11 @@ if(SYCL_COMPILER OR ENABLE_OMP_OFFLOAD)
     list(TRANSFORM MISSED_MKL_SYCL_LIBS PREPEND MKL:: OUTPUT_VARIABLE MISSED_MKL_SYCL_TARGETS)
     list(REMOVE_ITEM MKL_SYCL_LINK_LINE ${MISSED_MKL_SYCL_TARGETS})
     list(REMOVE_ITEM MKL_LINK_LINE ${MISSED_MKL_SYCL_TARGETS})
+    if(ENABLE_OMP_OFFLOAD)
+      set(MISSED_MKL_SYCL_TARGETS_STR "")
+      list(JOIN MISSED_MKL_SYCL_TARGETS " " MISSED_MKL_SYCL_TARGETS_STR)
+      mkl_message(WARNING "${MISSED_MKL_SYCL_TARGETS_STR} not found. MKL target will not fully support ENABLE_OMP_OFFLOAD feature.")
+    endif()
   endif()
 endif()
 
@@ -1061,7 +1038,6 @@ if(SYCL_COMPILER)
   if(NOT TARGET MKL::MKL_SYCL)
     add_library(MKL::MKL_SYCL INTERFACE IMPORTED GLOBAL)
     add_library(MKL::MKL_DPCPP ALIAS MKL::MKL_SYCL)
-    add_dependencies(MKL::MKL_SYCL MKL_SYCL_STATIC_MESSAGE)
   endif()
   target_compile_options(MKL::MKL_SYCL INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${MKL_SYCL_COPT}>)
   target_link_libraries(MKL::MKL_SYCL INTERFACE ${MKL_SYCL_LINK_LINE} ${MKL_SYCL_THREAD_LIB} ${MKL_SYCL_SUPP_LINK})
@@ -1076,13 +1052,9 @@ if(SYCL_COMPILER)
     add_library(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} INTERFACE IMPORTED GLOBAL)
     add_dependencies(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} MKL_SYCL_STATIC_MESSAGE)
     target_compile_options(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} INTERFACE $<$<COMPILE_LANGUAGE:CXX>:${MKL_SYCL_COPT}>)
-    # Only dynamic link has domain specific libraries
-    # Domain specific targets still use mkl_sycl for static
-    if(NOT MKL_LINK STREQUAL "static")
-      list(TRANSFORM MKL_SYCL_LINK_LINE REPLACE ".*mkl_sycl.*" "TBD")
-      list(REMOVE_DUPLICATES MKL_SYCL_LINK_LINE)
-      list(TRANSFORM MKL_SYCL_LINK_LINE REPLACE "TBD" "MKL::${lib}")
-    endif()
+    list(TRANSFORM MKL_SYCL_LINK_LINE REPLACE ".*mkl_sycl.*" "TBD")
+    list(REMOVE_DUPLICATES MKL_SYCL_LINK_LINE)
+    list(TRANSFORM MKL_SYCL_LINK_LINE REPLACE "TBD" "MKL::${lib}")
     target_link_libraries(MKL::MKL_SYCL::${MKL_SYCL_DOMAIN} INTERFACE ${MKL_SYCL_LINK_LINE} ${MKL_SYCL_THREAD_LIB} ${MKL_SYCL_SUPP_LINK})
     list(APPEND LINK_TYPES MKL::MKL_SYCL::${MKL_SYCL_DOMAIN})
   endforeach(lib) # MKL_SYCL_LIBS

--- a/cmake/mkl/MKLConfigVersion.cmake
+++ b/cmake/mkl/MKLConfigVersion.cmake
@@ -17,19 +17,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #===============================================================================
 
-set(PACKAGE_VERSION "2025.3.0")
+set(PACKAGE_VERSION "2026.0.0")
 
 if(PACKAGE_VERSION VERSION_LESS PACKAGE_FIND_VERSION)
   set(PACKAGE_VERSION_COMPATIBLE FALSE)
 else()
 
-  if("2025.3.0" MATCHES "^([0-9]+)\\.")
+  if("2026.0.0" MATCHES "^([0-9]+)\\.")
     set(CVF_VERSION_MAJOR "${CMAKE_MATCH_1}")
     if(NOT CVF_VERSION_MAJOR VERSION_EQUAL 0)
       string(REGEX REPLACE "^0+" "" CVF_VERSION_MAJOR "${CVF_VERSION_MAJOR}")
     endif()
   else()
-    set(CVF_VERSION_MAJOR "2025.3.0")
+    set(CVF_VERSION_MAJOR "2026.0.0")
   endif()
 
   if(PACKAGE_FIND_VERSION_RANGE)

--- a/src/blas/backends/mkl_common/mkl_level1.cxx
+++ b/src/blas/backends/mkl_common/mkl_level1.cxx
@@ -17,6 +17,199 @@
 * SPDX-License-Identifier: Apache-2.0
 *******************************************************************************/
 
+// Workaround for oneMKL 2026.0 SSE2 bug: iamax/iamin return incorrect indices with incx > 1
+// Only apply on MKLCPU backend where SSE2 fallback is used
+#if defined(ONEMATH_MKLCPU_BACKEND) && defined(__INTEL_MKL__) && __INTEL_MKL__ == 2026
+#define APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+#pragma message("oneMKL 2026.0 iamin/iamax workaround ENABLED for MKLCPU backend")
+
+namespace {
+
+// Helper: compute absolute value (magnitude) for iamin/iamax
+template <typename T>
+inline T abs_value(T val) {
+    return sycl::fabs(val);
+}
+
+template <typename T>
+inline T abs_value(std::complex<T> val) {
+    return sycl::fabs(val.real()) + sycl::fabs(val.imag());
+}
+
+// SYCL reference implementation of iamin for buffer API
+// Used as workaround for oneMKL 2026.0 SSE2 bug when |incx| > 1
+template <typename T>
+void sycl_iamin_impl(sycl::queue& queue, std::int64_t n, sycl::buffer<T, 1>& x, std::int64_t incx,
+                     sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    queue.submit([&](sycl::handler& cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
+
+        cgh.single_task([=]() {
+            if (n < 1 || incx < 1) {
+                res_acc[0] = 0;
+                return;
+            }
+
+            std::int64_t min_idx = 0;
+            auto min_val = abs_value(x_acc[0]);
+
+            if (sycl::isnan(min_val)) {
+                res_acc[0] = (base == oneapi::math::index_base::zero ? 0 : 1);
+                return;
+            }
+
+            std::int64_t abs_incx = (incx > 0) ? incx : -incx;
+            for (std::int64_t logical_i = 1; logical_i < n; ++logical_i) {
+                std::int64_t i = logical_i * abs_incx;
+                auto curr_val = abs_value(x_acc[i]);
+
+                if (sycl::isnan(curr_val)) {
+                    res_acc[0] = logical_i + (base == oneapi::math::index_base::zero ? 0 : 1);
+                    return;
+                }
+
+                if (curr_val < min_val) {
+                    min_idx = logical_i;
+                    min_val = curr_val;
+                }
+            }
+
+            res_acc[0] = min_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
+        });
+    });
+}
+
+// SYCL reference implementation of iamax for buffer API
+template <typename T>
+void sycl_iamax_impl(sycl::queue& queue, std::int64_t n, sycl::buffer<T, 1>& x, std::int64_t incx,
+                     sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
+    queue.submit([&](sycl::handler& cgh) {
+        auto x_acc = x.template get_access<sycl::access::mode::read>(cgh);
+        auto res_acc = result.template get_access<sycl::access::mode::write>(cgh);
+
+        cgh.single_task([=]() {
+            if (n < 1 || incx < 1) {
+                res_acc[0] = 0;
+                return;
+            }
+
+            std::int64_t max_idx = 0;
+            auto max_val = abs_value(x_acc[0]);
+
+            if (sycl::isnan(max_val)) {
+                res_acc[0] = (base == oneapi::math::index_base::zero ? 0 : 1);
+                return;
+            }
+
+            std::int64_t abs_incx = (incx > 0) ? incx : -incx;
+            for (std::int64_t logical_i = 1; logical_i < n; ++logical_i) {
+                std::int64_t i = logical_i * abs_incx;
+                auto curr_val = abs_value(x_acc[i]);
+
+                if (sycl::isnan(curr_val)) {
+                    res_acc[0] = logical_i + (base == oneapi::math::index_base::zero ? 0 : 1);
+                    return;
+                }
+
+                if (curr_val > max_val) {
+                    max_idx = logical_i;
+                    max_val = curr_val;
+                }
+            }
+
+            res_acc[0] = max_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
+        });
+    });
+}
+
+// SYCL reference implementation of iamin for USM API
+template <typename T>
+sycl::event sycl_iamin_usm_impl(sycl::queue& queue, std::int64_t n, const T* x, std::int64_t incx,
+                                std::int64_t* result, oneapi::math::index_base base,
+                                const std::vector<sycl::event>& dependencies) {
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        cgh.single_task([=]() {
+            if (n < 1 || incx < 1) {
+                *result = 0;
+                return;
+            }
+
+            std::int64_t min_idx = 0;
+            auto min_val = abs_value(x[0]);
+
+            if (sycl::isnan(min_val)) {
+                *result = (base == oneapi::math::index_base::zero ? 0 : 1);
+                return;
+            }
+
+            std::int64_t abs_incx = (incx > 0) ? incx : -incx;
+            for (std::int64_t logical_i = 1; logical_i < n; ++logical_i) {
+                std::int64_t i = logical_i * abs_incx;
+                auto curr_val = abs_value(x[i]);
+
+                if (sycl::isnan(curr_val)) {
+                    *result = logical_i + (base == oneapi::math::index_base::zero ? 0 : 1);
+                    return;
+                }
+
+                if (curr_val < min_val) {
+                    min_idx = logical_i;
+                    min_val = curr_val;
+                }
+            }
+
+            *result = min_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
+        });
+    });
+}
+
+// SYCL reference implementation of iamax for USM API
+template <typename T>
+sycl::event sycl_iamax_usm_impl(sycl::queue& queue, std::int64_t n, const T* x, std::int64_t incx,
+                                std::int64_t* result, oneapi::math::index_base base,
+                                const std::vector<sycl::event>& dependencies) {
+    return queue.submit([&](sycl::handler& cgh) {
+        cgh.depends_on(dependencies);
+        cgh.single_task([=]() {
+            if (n < 1 || incx < 1) {
+                *result = 0;
+                return;
+            }
+
+            std::int64_t max_idx = 0;
+            auto max_val = abs_value(x[0]);
+
+            if (sycl::isnan(max_val)) {
+                *result = (base == oneapi::math::index_base::zero ? 0 : 1);
+                return;
+            }
+
+            std::int64_t abs_incx = (incx > 0) ? incx : -incx;
+            for (std::int64_t logical_i = 1; logical_i < n; ++logical_i) {
+                std::int64_t i = logical_i * abs_incx;
+                auto curr_val = abs_value(x[i]);
+
+                if (sycl::isnan(curr_val)) {
+                    *result = logical_i + (base == oneapi::math::index_base::zero ? 0 : 1);
+                    return;
+                }
+
+                if (curr_val > max_val) {
+                    max_idx = logical_i;
+                    max_val = curr_val;
+                }
+            }
+
+            *result = max_idx + (base == oneapi::math::index_base::zero ? 0 : 1);
+        });
+    });
+}
+
+} // anonymous namespace
+#endif
+
 // Buffer APIs
 
 void asum(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
@@ -284,54 +477,126 @@ void swap(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>,
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamax_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamax_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamax_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamax(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamax_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamax(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<float, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamin_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<double, 1>& x, std::int64_t incx,
            sycl::buffer<std::int64_t, 1>& result, oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamin_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<float>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamin_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 void iamin(sycl::queue& queue, std::int64_t n, sycl::buffer<std::complex<double>, 1>& x,
            std::int64_t incx, sycl::buffer<std::int64_t, 1>& result,
            oneapi::math::index_base base) {
-    RETHROW_ONEMKL_EXCEPTIONS(
-        blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        sycl_iamin_impl(queue, n, x, incx, result, base);
+    }
+    else {
+#endif
+        RETHROW_ONEMKL_EXCEPTIONS(
+            blas_major::iamin(queue, n, x, incx, result, detail::get_onemkl_index_base(base)));
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    }
+#endif
 }
 
 // USM APIs
@@ -633,6 +898,11 @@ sycl::event swap(sycl::queue& queue, std::int64_t n, std::complex<double>* x, st
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamax_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -640,6 +910,11 @@ sycl::event iamax(sycl::queue& queue, std::int64_t n, const float* x, std::int64
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamax_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -647,6 +922,11 @@ sycl::event iamax(sycl::queue& queue, std::int64_t n, const double* x, std::int6
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamax_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -654,6 +934,11 @@ sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<float>*
 sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamax_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamax(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -661,6 +946,11 @@ sycl::event iamax(sycl::queue& queue, std::int64_t n, const std::complex<double>
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamin_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -668,6 +958,11 @@ sycl::event iamin(sycl::queue& queue, std::int64_t n, const float* x, std::int64
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x, std::int64_t incx,
                   std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamin_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -675,6 +970,11 @@ sycl::event iamin(sycl::queue& queue, std::int64_t n, const double* x, std::int6
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamin_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }
@@ -682,6 +982,11 @@ sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<float>*
 sycl::event iamin(sycl::queue& queue, std::int64_t n, const std::complex<double>* x,
                   std::int64_t incx, std::int64_t* result, oneapi::math::index_base base,
                   const std::vector<sycl::event>& dependencies) {
+#ifdef APPLY_ONEMKL_2026_IAMIN_IAMAX_WORKAROUND
+    if (std::abs(incx) > 1) {
+        return sycl_iamin_usm_impl(queue, n, x, incx, result, base, dependencies);
+    }
+#endif
     RETHROW_ONEMKL_EXCEPTIONS_RET(blas_major::iamin(
         queue, n, x, incx, result, detail::get_onemkl_index_base(base), dependencies));
 }

--- a/src/blas/backends/mklcpu/mklcpu_level1.cpp
+++ b/src/blas/backends/mklcpu/mklcpu_level1.cpp
@@ -27,6 +27,9 @@
 
 #include "../mkl_common/mkl_blas_backend.hpp"
 
+// Define backend identifier for conditional workarounds in mkl_common
+#define ONEMATH_MKLCPU_BACKEND
+
 namespace oneapi {
 namespace math {
 namespace blas {
@@ -47,3 +50,5 @@ namespace blas_major = ::oneapi::mkl::blas::row_major;
 } // namespace blas
 } // namespace math
 } // namespace oneapi
+
+#undef ONEMATH_MKLCPU_BACKEND


### PR DESCRIPTION
# Description

This PR updates Intel oneMKL version in github workflows and cmake to the latest 2026.0 release.

PR also applies W/A (falling to reference SYCL implementation) for oneMKL 2026.0 bug in BLAS iamax/iamin for incx > 1 cases that causes MKLCPU tests failure, I will remove W/A once it's fixed in the future oneMKL releases.

# Checklist

## All Submissions

- [X] Do all unit tests pass locally? Covered by github CI, ArmPL failures is known issue, not related.

